### PR TITLE
feat: pojo methods syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,10 @@ See the [events documentation](https://bentocache.dev/docs/events) for more info
 All TTLs can be passed in a human-readable string format. We use [lukeed/ms](https://github.com/lukeed/ms) under the hood. (this is optional, and you can pass a `number` in milliseconds if you prefer)
 
 ```ts
-bento.getOrSet('foo', () => getFromDb(), {
-  ttl: '2.5h'
-  gracePeriod: { enabled: true, duration: '6h' }
+bento.getOrSet({
+  key: 'foo',
+  ttl: '2.5h',
+  factory: () => getFromDb(),
 })
 ```
 
@@ -132,8 +133,10 @@ bento.getOrSet('foo', () => getFromDb(), {
 When you cached item will expire soon, you can refresh it in advance, in the background. This way, next time the entry is requested, it will already be computed and thus returned to the user super quickly.
 
 ```ts
-bento.getOrSet('foo', () => getFromDb(), {
+bento.getOrSet({
+  key: 'foo',
   earlyExpiration: 0.8
+  factory: () => getFromDb(),
 })
 ```
 

--- a/docs/content/docs/introduction.md
+++ b/docs/content/docs/introduction.md
@@ -132,9 +132,10 @@ See the [events documentation](./digging_deeper/events.md) for more information.
 All TTLs can be passed in a human-readable string format. We use [lukeed/ms](https://github.com/lukeed/ms) under the hood. (this is optional, and you can pass a `number` in milliseconds if you prefer)
 
 ```ts
-bento.getOrSet('foo', () => getFromDb(), {
+bento.getOrSet({
+  key: 'foo',
   ttl: '2.5h',
-  gracePeriod: { enabled: true, duration: '6h' }
+  factory: () => getFromDb(),
 })
 ```
 
@@ -143,8 +144,10 @@ bento.getOrSet('foo', () => getFromDb(), {
 When you cached item will expire soon, you can refresh it in advance, in the background. This way, next time the entry is requested, it will already be computed and thus returned to the user super quickly.
 
 ```ts
-bento.getOrSet('foo', () => getFromDb(), {
-  earlyExpiration: 0.8
+bento.getOrSet({
+  key: 'foo',
+  earlyExpiration: 0.8,
+  factory: () => getFromDb(),
 })
 ```
 

--- a/docs/content/docs/methods.md
+++ b/docs/content/docs/methods.md
@@ -6,6 +6,32 @@ summary: "Comprehensive list of all methods available when using BentoCache"
 
 Below is a list of all the methods available when using BentoCache.
 
+### Single object vs multiple arguments
+
+Most of the methods accept arguments in two different ways : either as a single argument or as an object. 
+
+If you need to pass some specific options, the object way is probably the best choice since it is more "vertical" and may be easier to read. On the other hand, the single argument may be more concise when you don't need to pass specific options.
+
+Example :
+
+```ts
+// multiple arguments
+await bento.getOrSet('products', () => fetchProducts(), {
+  ttl: '5m',
+  gracePeriod: { enabled: true, duration: '1m' },
+})
+
+// is equivalent to
+await bento.getOrSet({
+  key: 'products',
+  ttl: '5m',
+  factory: () => fetchProducts(),
+  gracePeriod: { enabled: true, duration: '1m' },
+})
+```
+
+---
+
 ### namespace
 
 Returns a new instance of the driver namespace. See [Namespaces](./namespaces.md) for more information.
@@ -22,7 +48,7 @@ usersNamespace.clear();
 
 ### get 
 
-`get` has multiple signatures and so it can be used in different ways.
+`get` allows you to retrieve a value from the cache. It returns `undefined` if the key does not exist.
 
 #### get(key: string)
 
@@ -53,6 +79,17 @@ const products = await bento.get<string>('products', [], {
 });
 ```
 
+#### get<T>(options: GetPojoOptions<T>) 
+
+Same as above, but with an object as argument.
+
+```ts
+const products = await bento.get({
+  key: 'products',
+  defaultValue: [],
+});
+```
+
 ### set
 
 Set a value in the cache.
@@ -62,6 +99,12 @@ await bento.set('products', products);
 await bento.set('products', products, {
   gracePeriod: { enabled: true, duration: '5m' }
 });
+
+await bento.set({
+  key: 'products',
+  value: products,
+  gracePeriod: { enabled: true, duration: '5m' }
+})
 ```
 
 ### setForever
@@ -70,6 +113,12 @@ Set a value in the cache forever. It will never expire.
 
 ```ts
 await bento.setForever('products', products);
+
+await bento.setForever({
+  key: 'products',
+  value: products,
+  gracePeriod: { enabled: true, duration: '5m' }
+})
 ```
 
 ### getOrSet
@@ -85,6 +134,14 @@ const products = await bento.getOrSet('products', () => fetchProducts())
 // with options
 const products = await bento.getOrSet('products', () => fetchProducts(), {
   ttl: '5m',
+  gracePeriod: { enabled: true, duration: '1m' },
+})
+
+// with options as object
+const products = await bento.getOrSet({
+  key: 'products',
+  ttl: '5m',
+  factory: () => fetchProducts(),
   gracePeriod: { enabled: true, duration: '1m' },
 })
 ```
@@ -107,6 +164,11 @@ Same as `getOrSet`, but the value will never expire.
 
 ```ts
 const products = await bento.getOrSetForever('products', () => fetchProducts())
+
+const products = await bento.getOrSetForever({
+  key: 'products',
+  factory: () => fetchProducts(),
+})
 ```
 
 ### has
@@ -115,6 +177,7 @@ Returns `true` if the key exists in the cache, `false` otherwise.
 
 ```ts
 const hasProducts = await bento.has('products');
+const hasProducts = await bento.has({ key: 'products' })
 ```
 
 ### missing
@@ -123,6 +186,7 @@ Returns `true` if the key does not exist in the cache, `false` otherwise.
 
 ```ts
 const missingProducts = await bento.missing('products');
+const missingProducts = await bento.missing({ key: 'products' })
 ```
 
 ### pull
@@ -131,6 +195,7 @@ Get the value of the key, and then delete it from the cache. Returns `undefined`
 
 ```ts
 const products = await bento.pull('products');
+const products = await bento.pull({ key: 'products' })
 ```
 
 ### delete
@@ -139,6 +204,7 @@ Delete a key from the cache.
 
 ```ts
 await bento.delete('products');
+await bento.delete({ key: 'products' })
 ```
 
 ### deleteMany
@@ -147,6 +213,7 @@ Delete multiple keys from the cache.
 
 ```ts
 await bento.deleteMany(['products', 'users']);
+await bento.deleteMany({ keys: ['products', 'users'] })
 ```
 
 ### clear

--- a/docs/content/docs/stampede_protection.md
+++ b/docs/content/docs/stampede_protection.md
@@ -14,11 +14,12 @@ Imagine this simple route that allows retrieving a post by its ID.
 ```ts
 router.get('/posts/:id', async (request) => {
   const { id } = request.params
-  const post = await bento.getOrSet(
-    `post:${id}`, 
-    () => getPostFromDb(id), 
-    { ttl: '1h' }
-  )
+  
+  const post = await bento.getOrSet({
+    key: `post:${id}`, 
+    ttl: '1h',
+    factory: () => getPostFromDb(id), 
+  })
   
   return user
 })

--- a/docs/content/docs/walkthrough.md
+++ b/docs/content/docs/walkthrough.md
@@ -47,11 +47,11 @@ const bento = new BentoCache({
 
 router.get('/products/:id', async (req, res) => {
   const productId = req.params.id
-  const product = await bento.getOrSet(
-    `product:${productId}`, 
-    () => Product.find(productId), 
-    { ttl: '1m' }
-  )
+  const product = await bento.getOrSet({
+    key: `product:${productId}`,
+    ttl: '1m',
+    factory: () => Product.find(productId),
+  })
 
   res.json(product)
 })
@@ -135,11 +135,11 @@ const bento = new BentoCache({
 
 router.get('/products/:id', async (req, res) => {
   const productId = req.params.id
-  const product = await bento.getOrSet(
-    `product:${productId}`, 
-    () => Product.find(productId), 
-    { ttl: '1m' }
-  )
+  const product = await bento.getOrSet({
+    key: `product:${productId}`,
+    ttl: '1m',
+    factory: () => Product.find(productId),
+  })
 
   res.json(product)
 })
@@ -207,11 +207,11 @@ const bento = new BentoCache({
 
 router.get('/products/:id', async (req, res) => {
   const productId = req.params.id
-  const product = await bento.getOrSet(
-    `product:${productId}`, 
-    () => Product.find(productId), 
-    { ttl: '1m' }
-  )
+  const product = await bento.getOrSet({
+    key: `product:${productId}`,
+    ttl: '1m',
+    factory: () => Product.find(productId),
+  })
 
   res.json(product)
 })
@@ -258,11 +258,11 @@ const bento = new BentoCache({
 
 router.get('/products/:id', async (req, res) => {
   const productId = req.params.id
-  const product = await bento.getOrSet(
-    `product:${productId}`, 
-    () => Product.find(productId), 
-    { ttl: '1m' }
-  )
+  const product = await bento.getOrSet({
+    key: `product:${productId}`,
+    ttl: '1m',
+    factory: () => Product.find(productId),
+  })
 
   res.json(product)
 })

--- a/packages/bentocache/src/bento_cache.ts
+++ b/packages/bentocache/src/bento_cache.ts
@@ -15,6 +15,12 @@ import type {
   HasOptions,
   ClearOptions,
   GetSetFactory,
+  GetOrSetPojoOptions,
+  GetPojoOptions,
+  SetPojoOptions,
+  HasPojoOptions,
+  DeletePojoOptions,
+  DeleteManyPojoOptions,
 } from './types/main.js'
 
 export class BentoCache<KnownCaches extends Record<string, BentoStore>> implements CacheProvider {
@@ -131,56 +137,94 @@ export class BentoCache<KnownCaches extends Record<string, BentoStore>> implemen
   /**
    * Get a value from the cache
    */
-  get<T = any>(key: string): Promise<T | undefined | null>
-  get<T = any>(key: string, defaultValue?: Factory<T>, options?: GetOptions): Promise<T>
-  async get<T = any>(key: string, defaultValue?: Factory<T>, rawOptions?: GetOptions): Promise<T> {
-    return this.use().get<T>(key, defaultValue, rawOptions)
+  async get<T = any>(
+    keyOrOptions: string | GetPojoOptions<T>,
+    defaultValue?: Factory<T>,
+    rawOptions?: GetOptions,
+  ): Promise<T> {
+    if (typeof keyOrOptions === 'string') {
+      return this.use().get<T>(keyOrOptions, defaultValue, rawOptions)
+    }
+
+    return this.use().get<T>(keyOrOptions)
   }
 
   /**
    * Put a value in the cache
    * Returns true if the value was set, false otherwise
    */
-  async set(key: string, value: any, options?: SetOptions) {
-    return this.use().set(key, value, options)
+  async set(keyOrOptions: string | SetPojoOptions, value?: any, options?: SetOptions) {
+    if (typeof keyOrOptions === 'string') {
+      return this.use().set(keyOrOptions, value, options)
+    }
+
+    return this.use().set(keyOrOptions)
   }
 
   /**
    * Put a value in the cache forever
    * Returns true if the value was set, false otherwise
    */
-  async setForever(key: string, value: any, options?: SetOptions) {
-    return this.use().setForever(key, value, options)
+  async setForever(keyOrOptions: string | SetPojoOptions, value?: any, options?: SetOptions) {
+    if (typeof keyOrOptions === 'string') {
+      return this.use().setForever(keyOrOptions, value, options)
+    }
+
+    return this.use().setForever(keyOrOptions)
   }
 
   /**
    * Retrieve an item from the cache if it exists, otherwise store the value
    * provided by the factory and return it
    */
-  async getOrSet<T>(key: string, factory: GetSetFactory<T>, options?: GetOrSetOptions): Promise<T> {
-    return this.use().getOrSet(key, factory, options)
+  async getOrSet<T>(
+    keyOrOptions: string | GetOrSetPojoOptions<T>,
+    factory?: GetSetFactory<T>,
+    options?: GetOrSetOptions,
+  ): Promise<T> {
+    if (typeof keyOrOptions === 'string') {
+      return this.use().getOrSet(keyOrOptions, factory!, options)
+    }
+
+    return this.use().getOrSet(keyOrOptions)
   }
 
   /**
    * Retrieve an item from the cache if it exists, otherwise store the value
    * provided by the factory forever and return it
    */
-  getOrSetForever<T>(key: string, cb: GetSetFactory<T>, opts?: GetOrSetOptions): Promise<T> {
-    return this.use().getOrSetForever(key, cb, opts)
+  getOrSetForever<T>(
+    key: string | GetOrSetPojoOptions<T>,
+    cb?: GetSetFactory<T>,
+    opts?: GetOrSetOptions,
+  ): Promise<T> {
+    if (typeof key === 'string') {
+      return this.use().getOrSetForever(key, cb!, opts)
+    }
+
+    return this.use().getOrSetForever(key)
   }
 
   /**
    * Check if a key exists in the cache
    */
-  async has(key: string, options?: HasOptions) {
-    return this.use().has(key, options)
+  async has(keyOrOptions: string | HasPojoOptions, options?: HasOptions) {
+    if (typeof keyOrOptions === 'string') {
+      return this.use().has(keyOrOptions, options)
+    }
+
+    return this.use().has(keyOrOptions)
   }
 
   /**
    * Check if key is missing in the cache
    */
-  async missing(key: string, options?: HasOptions) {
-    return this.use().missing(key, options)
+  async missing(keyOrOptions: string | HasPojoOptions, options?: HasOptions) {
+    if (typeof keyOrOptions === 'string') {
+      return this.use().missing(keyOrOptions, options)
+    }
+
+    return this.use().missing(keyOrOptions)
   }
 
   /**
@@ -196,15 +240,26 @@ export class BentoCache<KnownCaches extends Record<string, BentoStore>> implemen
    * Delete a key from the cache
    * Returns true if the key was deleted, false otherwise
    */
-  async delete(key: string, options?: DeleteOptions) {
-    return this.use().delete(key, options)
+  async delete(keyOrOptions: string | DeletePojoOptions, options?: DeleteOptions) {
+    if (typeof keyOrOptions === 'string') {
+      return this.use().delete(keyOrOptions, options)
+    }
+
+    return this.use().delete(keyOrOptions)
   }
 
   /**
    * Delete multiple keys from the cache
    */
-  async deleteMany(keys: string[], options?: DeleteOptions): Promise<boolean> {
-    return this.use().deleteMany(keys, options)
+  async deleteMany(
+    keysOrOptions: string[] | DeleteManyPojoOptions,
+    options?: DeleteOptions,
+  ): Promise<boolean> {
+    if (Array.isArray(keysOrOptions)) {
+      return this.use().deleteMany(keysOrOptions, options)
+    }
+
+    return this.use().deleteMany(keysOrOptions)
   }
 
   /**

--- a/packages/bentocache/src/bento_cache.ts
+++ b/packages/bentocache/src/bento_cache.ts
@@ -137,6 +137,9 @@ export class BentoCache<KnownCaches extends Record<string, BentoStore>> implemen
   /**
    * Get a value from the cache
    */
+  get<T = any>(options: GetPojoOptions<T>): Promise<T>
+  get<T = any>(key: string): Promise<T | null | undefined>
+  get<T = any>(key: string, defaultValue: Factory<T>, options?: GetOptions): Promise<T>
   async get<T = any>(
     keyOrOptions: string | GetPojoOptions<T>,
     defaultValue?: Factory<T>,

--- a/packages/bentocache/src/cache/cache.ts
+++ b/packages/bentocache/src/cache/cache.ts
@@ -50,6 +50,9 @@ export class Cache implements CacheProvider {
     return new Cache(this.name, this.#stack.namespace(namespace))
   }
 
+  get<T = any>(options: GetPojoOptions<T>): Promise<T>
+  get<T = any>(key: string): Promise<T | null | undefined>
+  get<T = any>(key: string, defaultValue: Factory<T>, options?: GetOptions): Promise<T>
   async get<T = any>(
     keyOrOptions: string | GetPojoOptions<T>,
     defaultValue?: Factory<T>,
@@ -100,6 +103,9 @@ export class Cache implements CacheProvider {
       this.#stack.emit(new events.CacheHit(key, localItem.serialize(), this.name, true))
       return localItem.getValue()
     }
+
+    this.#stack.emit(new events.CacheMiss(key, this.name))
+    return this.#resolveDefaultValue(defaultValueFn)
   }
 
   /**

--- a/packages/bentocache/src/types/options/methods_options.ts
+++ b/packages/bentocache/src/types/options/methods_options.ts
@@ -1,4 +1,4 @@
-import type { RawCommonOptions } from '../main.js'
+import type { Factory, GetSetFactory, RawCommonOptions } from '../main.js'
 
 /**
  * Options accepted by the `getOrSet` method
@@ -9,17 +9,32 @@ export type GetOrSetOptions = Pick<
 >
 
 /**
+ * Options accepted by the `getOrSet` method when passing an object
+ */
+export type GetOrSetPojoOptions<T> = { key: string; factory: GetSetFactory<T> } & GetOrSetOptions
+
+/**
  * Options accepted by the `set` method
  */
 export type SetOptions = GetOrSetOptions
+
+/*
+ * Options accepted by the `set` method when passing an object
+ */
+export type SetPojoOptions = { key: string; value: any } & SetOptions
 
 /**
  * Options accepted by the `get` method
  */
 export type GetOptions = Pick<
   RawCommonOptions,
-  'earlyExpiration' | 'gracePeriod' | 'suppressL2Errors' | 'ttl'
+  'earlyExpiration' | 'gracePeriod' | 'suppressL2Errors'
 >
+
+/**
+ * Options accepted by the `get` method when passing an object
+ */
+export type GetPojoOptions<T> = { key: string; defaultValue?: Factory<T> } & GetOptions
 
 /**
  * Options accepted by the `delete` method
@@ -27,9 +42,20 @@ export type GetOptions = Pick<
 export type DeleteOptions = Pick<RawCommonOptions, 'suppressL2Errors'>
 
 /**
+ * Options accepted by the `delete` method when passing an object
+ */
+export type DeletePojoOptions = { key: string } & DeleteOptions
+export type DeleteManyPojoOptions = { keys: string[] } & DeleteOptions
+
+/**
  * Options accepted by the `has` method
  */
 export type HasOptions = Pick<RawCommonOptions, 'suppressL2Errors'>
+
+/**
+ * Options accepted by the `has` method when passing an object
+ */
+export type HasPojoOptions = { key: string } & HasOptions
 
 /**
  * Options accepted by the `clear` method

--- a/packages/bentocache/src/types/provider.ts
+++ b/packages/bentocache/src/types/provider.ts
@@ -38,6 +38,7 @@ export interface CacheProvider {
    */
   get<T = any>(options: GetPojoOptions<T>): Promise<T>
   get<T = any>(key: string, defaultValue?: Factory<T>, options?: GetOptions): Promise<T>
+  get<T = any>(key: string): Promise<T | null | undefined>
 
   /**
    * Get or set a value in the cache

--- a/packages/bentocache/src/types/provider.ts
+++ b/packages/bentocache/src/types/provider.ts
@@ -1,11 +1,17 @@
 import type { Factory, GetSetFactory } from './helpers.js'
 import type {
   ClearOptions,
+  DeleteManyPojoOptions,
   DeleteOptions,
+  DeletePojoOptions,
   GetOptions,
   GetOrSetOptions,
+  GetOrSetPojoOptions,
+  GetPojoOptions,
   HasOptions,
+  HasPojoOptions,
   SetOptions,
+  SetPojoOptions,
 } from './main.js'
 
 /**
@@ -17,33 +23,26 @@ export interface CacheProvider {
    * Set a value in the cache
    * Returns true if the value was set, false otherwise
    */
+  set(options: SetPojoOptions): Promise<boolean>
   set(key: string, value: any, options?: SetOptions): Promise<boolean>
 
   /**
    * Set a value in the cache forever
    */
+  setForever(options: SetPojoOptions): Promise<boolean>
   setForever(key: string, value: any, options?: SetOptions): Promise<boolean>
-
-  /**
-   * Get a value from the cache
-   *
-   * @param key Key to get
-   */
-  get<T>(key: string): Promise<T | undefined | null>
 
   /**
    * Get a value from the cache, fallback to a default value
    * and set options
-   *
-   * @param key  Key to get
-   * @param defaultValue Default value if the key is not found
-   * @param options Options to set
    */
+  get<T = any>(options: GetPojoOptions<T>): Promise<T>
   get<T = any>(key: string, defaultValue?: Factory<T>, options?: GetOptions): Promise<T>
 
   /**
    * Get or set a value in the cache
    */
+  getOrSet<T>(options: GetOrSetPojoOptions<T>): Promise<T>
   getOrSet<T>(
     key: string,
     factory: GetSetFactory<T>,
@@ -53,21 +52,19 @@ export interface CacheProvider {
   /**
    * Get or set a value in the cache forever
    */
+  getOrSetForever<T>(options: GetOrSetPojoOptions<T>): Promise<T>
   getOrSetForever<T>(key: string, cb: GetSetFactory<T>, opts?: GetOrSetOptions): Promise<T>
-
-  /**
-   * Returns a new instance of the driver namespaced
-   */
-  namespace(namespace: string): CacheProvider
 
   /**
    * Check if a key exists in the cache
    */
+  has(options: HasPojoOptions): Promise<boolean>
   has(key: string, options?: HasOptions): Promise<boolean>
 
   /**
    * Check if a key is missing from the cache
    */
+  missing(options: HasPojoOptions): Promise<boolean>
   missing(key: string, options?: HasOptions): Promise<boolean>
 
   /**
@@ -81,17 +78,24 @@ export interface CacheProvider {
    * Delete a key from the cache
    * Returns true if the key was deleted, false otherwise
    */
+  delete(options: DeletePojoOptions): Promise<boolean>
   delete(key: string, options?: DeleteOptions): Promise<boolean>
 
   /**
    * Delete multiple keys from the cache
    */
+  deleteMany(options: DeleteManyPojoOptions): Promise<boolean>
   deleteMany(keys: string[], options?: DeleteOptions): Promise<boolean>
 
   /**
    * Remove all items from the cache
    */
   clear(options?: ClearOptions): Promise<void>
+
+  /**
+   * Returns a new instance of the driver namespaced
+   */
+  namespace(namespace: string): CacheProvider
 
   /**
    * Closes the connection to the cache

--- a/packages/bentocache/tests/bento_cache.spec.ts
+++ b/packages/bentocache/tests/bento_cache.spec.ts
@@ -35,8 +35,8 @@ test.group('Bento Cache', () => {
       assert.equal(event.value, 'bar')
     })
 
-    await bento.set('foo', 'bar')
-    await bento.get('foo')
+    await bento.set({ key: 'foo', value: 'bar' })
+    await bento.get({ key: 'foo' })
   })
 
   test('Unsubscribe from an event', async ({ assert }) => {

--- a/packages/bentocache/tests/cache/one_tier_local.spec.ts
+++ b/packages/bentocache/tests/cache/one_tier_local.spec.ts
@@ -600,14 +600,14 @@ test.group('One tier tests', () => {
   test('adaptive caching', async ({ assert }) => {
     const { cache, local, stack } = new CacheFactory().withMemoryL1().merge({ ttl: '10m' }).create()
 
-    await cache.getOrSet(
-      'key1',
-      (options) => {
+    await cache.getOrSet({
+      key: 'key1',
+      ttl: '4m',
+      factory: (options) => {
         options.setTtl('2d')
         return { foo: 'bar' }
       },
-      { ttl: '4m' },
-    )
+    })
 
     const res = local.get('key1', stack.defaultOptions)!
     const logicalExpiration = res.getLogicalExpiration()

--- a/packages/bentocache/tests/cache/one_tier_local.spec.ts
+++ b/packages/bentocache/tests/cache/one_tier_local.spec.ts
@@ -66,6 +66,20 @@ test.group('One tier tests', () => {
     assert.isUndefined(r2)
   })
 
+  test('get() with grace period and default value but no fallback value', async ({ assert }) => {
+    const { cache } = new CacheFactory()
+      .withMemoryL1()
+      .merge({ gracePeriod: { enabled: true, duration: '4h' } })
+      .create()
+
+    const result = await cache.get({
+      key: 'key',
+      defaultValue: 'default',
+    })
+
+    assert.equal(result, 'default')
+  })
+
   test('get() should not use grace period when disabled', async ({ assert }) => {
     const { cache } = new CacheFactory()
       .withMemoryL1()

--- a/packages/bentocache/tests/cache/one_tier_local.spec.ts
+++ b/packages/bentocache/tests/cache/one_tier_local.spec.ts
@@ -527,48 +527,46 @@ test.group('One tier tests', () => {
     assert.isUndefined(r2?.getEarlyExpiration())
   })
 
-  for (let i = 0; i < 300; i++) {
-    test('early refresh should re-increment physical/logical ttls', async ({ assert }) => {
-      const { cache } = new CacheFactory()
-        .withMemoryL1()
-        .merge({ earlyExpiration: 0.5, ttl: '500ms' })
-        .create()
+  test('early refresh should re-increment physical/logical ttls', async ({ assert }) => {
+    const { cache } = new CacheFactory()
+      .withMemoryL1()
+      .merge({ earlyExpiration: 0.5, ttl: '500ms' })
+      .create()
 
-      // init cache
-      const r1 = await cache.getOrSet('key1', () => ({ foo: 'bar' }))
+    // init cache
+    const r1 = await cache.getOrSet('key1', () => ({ foo: 'bar' }))
 
-      // wait for early refresh threshold
-      await setTimeout(350)
+    // wait for early refresh threshold
+    await setTimeout(350)
 
-      // call factory. should returns the old value.
-      // Disable early expiration to test physical ttl
-      const r2 = await cache.getOrSet({
-        key: 'key1',
-        factory: slowFactory(50, { foo: 'baz' }),
-        earlyExpiration: undefined,
-      })
-
-      // wait for early refresh to be done
-      await setTimeout(60)
-
-      // get the value
-      const r3 = await cache.get('key1')
-
-      // wait a bit
-      await setTimeout(50)
-      const r4 = await cache.get('key1')
-
-      // wait for physical ttl to expire
-      await setTimeout(600)
-      const r5 = await cache.get('key1')
-
-      assert.deepEqual(r1, { foo: 'bar' })
-      assert.deepEqual(r2, { foo: 'bar' })
-      assert.deepEqual(r3, { foo: 'baz' })
-      assert.deepEqual(r4, { foo: 'baz' })
-      assert.isUndefined(r5)
+    // call factory. should returns the old value.
+    // Disable early expiration to test physical ttl
+    const r2 = await cache.getOrSet({
+      key: 'key1',
+      factory: slowFactory(50, { foo: 'baz' }),
+      earlyExpiration: undefined,
     })
-  }
+
+    // wait for early refresh to be done
+    await setTimeout(60)
+
+    // get the value
+    const r3 = await cache.get('key1')
+
+    // wait a bit
+    await setTimeout(50)
+    const r4 = await cache.get('key1')
+
+    // wait for physical ttl to expire
+    await setTimeout(600)
+    const r5 = await cache.get('key1')
+
+    assert.deepEqual(r1, { foo: 'bar' })
+    assert.deepEqual(r2, { foo: 'bar' })
+    assert.deepEqual(r3, { foo: 'baz' })
+    assert.deepEqual(r4, { foo: 'baz' })
+    assert.isUndefined(r5)
+  })
 
   test('soft timeout should returns old value if factory take too long', async ({ assert }) => {
     const { cache } = new CacheFactory()

--- a/packages/bentocache/tests/cache/one_tier_local.spec.ts
+++ b/packages/bentocache/tests/cache/one_tier_local.spec.ts
@@ -72,9 +72,10 @@ test.group('One tier tests', () => {
       .merge({ gracePeriod: { enabled: false, duration: '500ms' } })
       .create()
 
-    // init key with grace period
-    await cache.getOrSet('key', () => 'value', {
+    await cache.getOrSet({
+      key: 'key',
       ttl: '10ms',
+      factory: () => 'value',
       gracePeriod: { enabled: true, duration: '500ms' },
     })
 

--- a/packages/bentocache/tests/cache/two_tier.spec.ts
+++ b/packages/bentocache/tests/cache/two_tier.spec.ts
@@ -389,16 +389,18 @@ test.group('Cache', () => {
     const r1 = await cache.getOrSet('key1', () => ({ foo: 'bar' }))
 
     // wait for early refresh threshold
-    await setTimeout(60)
+    await setTimeout(350)
 
     // call factory. should returns the old value.
     // Disable early expiration to test physical ttl
-    const r2 = await cache.getOrSet('key1', slowFactory(50, { foo: 'baz' }), {
+    const r2 = await cache.getOrSet({
+      key: 'key1',
+      factory: slowFactory(50, { foo: 'baz' }),
       earlyExpiration: undefined,
     })
 
     // wait for early refresh to be done
-    await setTimeout(50)
+    await setTimeout(60)
 
     // get the value
     const r3 = await cache.get('key1')
@@ -408,7 +410,7 @@ test.group('Cache', () => {
     const r4 = await cache.get('key1')
 
     // wait for physical ttl to expire
-    await setTimeout(50)
+    await setTimeout(600)
     const r5 = await cache.get('key1')
 
     assert.deepEqual(r1, { foo: 'bar' })

--- a/packages/bentocache/tests/typings.spec.ts
+++ b/packages/bentocache/tests/typings.spec.ts
@@ -90,10 +90,16 @@ test.group('Typings', () => {
     const r1 = await cache.getOrSet<string>('key', () => 'hey')
     const r2 = await cache.getOrSet('key', () => 32)
     const r3 = await cache.getOrSet('key', () => 50_000)
+    const r4 = await cache.getOrSet({
+      key: 'key',
+      ttl: 1000,
+      factory: () => 34,
+    })
 
     expectTypeOf(r1).toEqualTypeOf<string>()
     expectTypeOf(r2).toEqualTypeOf<number>()
     expectTypeOf(r3).toEqualTypeOf<number>()
+    expectTypeOf(r4).toEqualTypeOf<number>()
   })
 
   test('getOrSet() typings on bento', async ({ expectTypeOf }) => {
@@ -102,10 +108,16 @@ test.group('Typings', () => {
     const r1 = await bento.getOrSet<string>('key', () => 'hey')
     const r2 = await bento.getOrSet('key', () => 32)
     const r3 = await bento.getOrSet('key', () => 50_000)
+    const r4 = await bento.getOrSet({
+      key: 'key',
+      ttl: 1000,
+      factory: () => 34,
+    })
 
     expectTypeOf(r1).toEqualTypeOf<string>()
     expectTypeOf(r2).toEqualTypeOf<number>()
     expectTypeOf(r3).toEqualTypeOf<number>()
+    expectTypeOf(r4).toEqualTypeOf<number>()
   })
 
   test('on() events list', async ({ expectTypeOf }) => {


### PR DESCRIPTION
Most of the methods now accept arguments in two different ways : either as a single argument or as an object. 

If you need to pass some specific options, the object way is probably the best choice since it is more "vertical" and may be easier to read. On the other hand, the single argument may be more concise when you don't need to pass specific options.

Example :

```ts
// multiple arguments
await bento.getOrSet('products', () => fetchProducts(), {
  ttl: '5m',
  gracePeriod: { enabled: true, duration: '1m' },
})

// is equivalent to
await bento.getOrSet({
  key: 'products',
  ttl: '5m',
  factory: () => fetchProducts(),
  gracePeriod: { enabled: true, duration: '1m' },
})
```