### PR TITLE
fix: base64 encode and decoded in the binary encoder to avoid possible crash

### DIFF
--- a/packages/bentocache/package.json
+++ b/packages/bentocache/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "bentocache",
+  "name": "@gk8/bentocache",
   "type": "module",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "description": "Multi-tier cache module for Node.js. Redis, Upstash, CloudfareKV, File, in-memory and others drivers",
   "author": "Julien Ripouteau <julien@ripouteau.com>",
   "license": "MIT",

--- a/packages/bentocache/src/bus/encoders/binary_encoder.ts
+++ b/packages/bentocache/src/bus/encoders/binary_encoder.ts
@@ -80,7 +80,7 @@ export class BinaryEncoder implements TransportEncoder {
       offset += keyLength
     }
 
-    return buffer
+    return buffer.toString('base64')
   }
 
   /**
@@ -88,7 +88,7 @@ export class BinaryEncoder implements TransportEncoder {
    */
   decode(data: string): any {
     let offset = 0
-    const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data, 'binary')
+    const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data, 'base64')
 
     /**
      * First #busIdLength bytes are the bus ID


### PR DESCRIPTION
Fixes #19 while passing the binary encode/decode tests