### PR TITLE
Added Test Case for Synchronizing Multiple Cache with Namespace

### DIFF
--- a/packages/bentocache/tests/bus/bus.spec.ts
+++ b/packages/bentocache/tests/bus/bus.spec.ts
@@ -33,6 +33,29 @@ test.group('Bus synchronization', () => {
     assert.isUndefined(await cache3.get(key))
   }).disableTimeout()
 
+  test('synchronize multiple cache with namespace', async ({ assert }) => {
+    const key = 'foo'
+
+    const [cache1] = new CacheFactory().withL1L2Config().create()
+    const [cache2] = new CacheFactory().withL1L2Config().create()
+    const [cache3] = new CacheFactory().withL1L2Config().create()
+
+    await cache1.namespace('users').set(key, 24)
+    await setTimeout(100)
+
+    assert.equal(await cache1.namespace('users').get(key), 24)
+    assert.equal(await cache2.namespace('users').get(key), 24)
+    assert.equal(await cache3.namespace('users').get(key), 24)
+
+    await cache1.namespace('users').delete(key)
+
+    await setTimeout(100)
+
+    assert.isUndefined(await cache1.namespace('users').get(key))
+    assert.isUndefined(await cache2.namespace('users').get(key))
+    assert.isUndefined(await cache3.namespace('users').get(key))
+  }).disableTimeout()
+
   test('retry queue processing', async ({ assert }) => {
     const bus1 = new ChaosBus(new MemoryTransport())
     const bus2 = new ChaosBus(new MemoryTransport())


### PR DESCRIPTION
This pull request introduces a new test case to handle synchronization of multiple caches with namespaces, which is currently not addressed. The test verifies if changes made in one cache (within a specific namespace) are propagated correctly across other caches created with the same configuration.

**Issue**:
The test case fails because the namespace is not being properly cleared across all caches. When a key is deleted from the namespace in one cache, it should be deleted across all caches, but currently, the data remains in some of the caches.

**Impact**:
This issue can lead to inconsistent data across multiple caches when working with namespaced data. This pull request aims to highlight the need for synchronization of cache data across instances within the same namespace.