### PR TITLE
fix: clear message goes to all bus instances + refactor: to optimize bus sync

### DIFF
--- a/packages/bentocache/src/cache/cache.ts
+++ b/packages/bentocache/src/cache/cache.ts
@@ -217,7 +217,7 @@ export class Cache implements CacheProvider {
 
     this.#stack.emit(new events.CacheDeleted(key, this.name))
 
-    await this.#stack.bus?.publish({ type: CacheBusMessageType.Delete, keys: [key] })
+    await this.#stack.publish({ type: CacheBusMessageType.Delete, keys: [key] })
 
     return true
   }
@@ -240,7 +240,7 @@ export class Cache implements CacheProvider {
 
     keys.forEach((key) => this.#stack.emit(new events.CacheDeleted(key, this.name)))
 
-    await this.#stack.bus?.publish({ type: CacheBusMessageType.Delete, keys })
+    await this.#stack.publish({ type: CacheBusMessageType.Delete, keys })
 
     return true
   }
@@ -254,7 +254,7 @@ export class Cache implements CacheProvider {
     await Promise.all([
       this.#stack.l1?.clear(),
       this.#stack.l2?.clear(cacheOptions),
-      this.#stack.bus?.publish({ type: CacheBusMessageType.Clear, keys: [] }),
+      this.#stack.publish({ type: CacheBusMessageType.Clear, keys: [] }),
     ])
 
     this.#stack.emit(new events.CacheCleared(this.name))

--- a/packages/bentocache/src/cache/stack/cache_stack.ts
+++ b/packages/bentocache/src/cache/stack/cache_stack.ts
@@ -59,7 +59,7 @@ export class CacheStack {
     return newBus
   }
 
-  namespace(namespace: string) {
+  namespace(namespace: string): CacheStack {
     if (!this.#namespaceCache.has(namespace)) {
       this.#namespaceCache.set(
         namespace,
@@ -72,7 +72,7 @@ export class CacheStack {
       )
     }
 
-    return this.#namespaceCache.get(namespace)
+    return <CacheStack>this.#namespaceCache.get(namespace)
   }
 
   emit(event: CacheEvent) {

--- a/packages/bentocache/src/cache/stack/cache_stack.ts
+++ b/packages/bentocache/src/cache/stack/cache_stack.ts
@@ -63,7 +63,7 @@ export class CacheStack {
       l1Driver: this.l1?.namespace(namespace),
       l2Driver: this.l2?.namespace(namespace),
       busDriver: this.#busDriver,
-      busOptions: this.#busOptions,
+      busOptions: { ...this.#busOptions, prefix: this.bus?.namespace(namespace) },
     })
   }
 

--- a/packages/bentocache/src/cache/stack/cache_stack.ts
+++ b/packages/bentocache/src/cache/stack/cache_stack.ts
@@ -3,6 +3,7 @@ import lodash from '@poppinss/utils/lodash'
 import { Bus } from '../../bus/bus.js'
 import { LocalCache } from '../facades/local_cache.js'
 import { RemoteCache } from '../facades/remote_cache.js'
+import { BaseDriver } from '../../drivers/base_driver.js'
 import { JsonSerializer } from '../../serializers/json.js'
 import type { BentoCacheOptions } from '../../bento_cache_options.js'
 import { CacheEntryOptions } from '../cache_entry/cache_entry_options.js'
@@ -11,10 +12,11 @@ import type {
   BusOptions,
   CacheEvent,
   CacheStackDrivers,
+  CacheBusMessage,
   Logger,
 } from '../../types/main.js'
 
-export class CacheStack {
+export class CacheStack extends BaseDriver {
   #serializer = new JsonSerializer()
 
   l1?: LocalCache
@@ -32,12 +34,15 @@ export class CacheStack {
     drivers: CacheStackDrivers,
     bus?: Bus,
   ) {
+    super(options)
     this.logger = options.logger.child({ cache: this.name })
 
     if (drivers.l1Driver) this.l1 = new LocalCache(drivers.l1Driver, this.logger)
     if (drivers.l2Driver) this.l2 = new RemoteCache(drivers.l2Driver, this.logger)
 
-    this.bus = this.#createBus(drivers.busDriver, bus, drivers.busOptions)
+    this.bus = bus ? bus : this.#createBus(drivers.busDriver, drivers.busOptions)
+    if (this.l1) this.bus?.manageCache(this.prefix, this.l1)
+
     this.defaultOptions = new CacheEntryOptions(options)
   }
 
@@ -45,16 +50,15 @@ export class CacheStack {
     return this.options.emitter
   }
 
-  #createBus(busDriver?: BusDriver, bus?: Bus, busOptions?: BusOptions) {
-    if (bus) return bus
-    if (!busDriver || !this.l1) return
+  #createBus(busDriver?: BusDriver, busOptions?: BusOptions) {
+    if (!busDriver) return
 
     this.#busDriver = busDriver
     this.#busOptions = lodash.merge(
       { retryQueue: { enabled: true, maxSize: undefined } },
       busOptions,
     )
-    const newBus = new Bus(this.#busDriver, this.l1, this.logger, this.emitter, this.#busOptions)
+    const newBus = new Bus(this.name, this.#busDriver, this.logger, this.emitter, this.#busOptions)
 
     return newBus
   }
@@ -63,16 +67,29 @@ export class CacheStack {
     if (!this.#namespaceCache.has(namespace)) {
       this.#namespaceCache.set(
         namespace,
-        new CacheStack(this.name, this.options, {
-          l1Driver: this.l1?.namespace(namespace),
-          l2Driver: this.l2?.namespace(namespace),
-          busDriver: this.#busDriver,
-          busOptions: { ...this.#busOptions, prefix: this.bus?.namespace(namespace) },
-        }),
+        new CacheStack(
+          this.name,
+          this.options.cloneWith({ prefix: this.createNamespacePrefix(namespace) }),
+          {
+            l1Driver: this.l1?.namespace(namespace),
+            l2Driver: this.l2?.namespace(namespace),
+          },
+          this.bus,
+        ),
       )
     }
 
     return <CacheStack>this.#namespaceCache.get(namespace)
+  }
+
+  /**
+   * Publish a message to the bus channel
+   *
+   * @returns true if the message was published, false if not
+   * and undefined if a bus is not part of the stack
+   */
+  async publish(message: CacheBusMessage): Promise<boolean | undefined> {
+    return this.bus?.publish({ ...message, namespace: this.prefix })
   }
 
   emit(event: CacheEvent) {

--- a/packages/bentocache/src/cache/stack/cache_stack_writer.ts
+++ b/packages/bentocache/src/cache/stack/cache_stack_writer.ts
@@ -22,7 +22,7 @@ export class CacheStackWriter {
 
     this.cacheStack.l1?.set(key, item, options)
     await this.cacheStack.l2?.set(key, item, options)
-    await this.cacheStack.bus?.publish({ type: CacheBusMessageType.Set, keys: [key] })
+    await this.cacheStack.publish({ type: CacheBusMessageType.Set, keys: [key] })
 
     this.cacheStack.emit(new CacheWritten(key, value, this.cacheStack.name))
     return true

--- a/packages/bentocache/src/types/bus.ts
+++ b/packages/bentocache/src/types/bus.ts
@@ -1,6 +1,7 @@
 import type { Transport } from '@boringnode/bus/types/main'
 
 import type { Duration } from './helpers.js'
+import type { DriverCommonOptions } from './main.js'
 
 /**
  * Interface for the bus driver
@@ -53,4 +54,4 @@ export type BusOptions = {
      */
     retryInterval?: Duration | false
   }
-}
+} & DriverCommonOptions

--- a/packages/bentocache/src/types/bus.ts
+++ b/packages/bentocache/src/types/bus.ts
@@ -1,7 +1,6 @@
 import type { Transport } from '@boringnode/bus/types/main'
 
 import type { Duration } from './helpers.js'
-import type { DriverCommonOptions } from './main.js'
 
 /**
  * Interface for the bus driver
@@ -14,6 +13,7 @@ export type BusDriver = Transport
 export type CacheBusMessage = {
   keys: string[]
   type: CacheBusMessageType
+  namespace?: string
 }
 
 export enum CacheBusMessageType {
@@ -54,4 +54,4 @@ export type BusOptions = {
      */
     retryInterval?: Duration | false
   }
-} & DriverCommonOptions
+}

--- a/packages/bentocache/tests/bus/bus.spec.ts
+++ b/packages/bentocache/tests/bus/bus.spec.ts
@@ -69,6 +69,7 @@ test.group('Bus synchronization', () => {
 
     await cache1NSUsersMe.set(key, 24)
     await cache3NSAdmin.set(key, 42)
+    await cache1.set(key, 33)
     await setTimeout(100)
 
     assert.equal(await cache1NSUsersMe.get(key), 24)
@@ -87,6 +88,11 @@ test.group('Bus synchronization', () => {
     await setTimeout(100)
 
     assert.isUndefined(await cache3NSAdmin.get(key))
+    assert.equal(await cache2.get(key), 33)
+    await cache2.delete(key)
+    await setTimeout(100)
+
+    assert.isUndefined(await cache1.get(key))
   }).disableTimeout()
 
   test('synchronize clear across namespaces', async ({ assert }) => {
@@ -312,6 +318,7 @@ test.group('Bus synchronization', () => {
     const data = {
       keys: [],
       type: CacheBusMessageType.Clear,
+      namespace: 'users',
     }
 
     bus1.subscribe('foo', (message: any) => {


### PR DESCRIPTION
Since the channel name is the same, clear is called on all L1 instances of any cache stack with a sync bus. Clearing one namespace will clear the local caches on remote instances for ALL namespaces. Issues related to this are masked, since this only impacts the L1 cache and the L2 cache of other namespaces are still preserved.

However, since this will cause unnecessary processing of messages and clearing of L1 caches, I have added a namespace to the channel name of the bus to overcome this.