### PR TITLE
Handle deleteMany with empty keys list

### DIFF
--- a/.changeset/khaki-days-clean.md
+++ b/.changeset/khaki-days-clean.md
@@ -1,0 +1,5 @@
+---
+"bentocache": patch
+---
+
+Handle deleteMany with empty keys list

--- a/packages/bentocache/src/drivers/database/database.ts
+++ b/packages/bentocache/src/drivers/database/database.ts
@@ -156,6 +156,7 @@ export class DatabaseDriver extends BaseDriver implements CacheDriver<true> {
    * Delete multiple keys from the cache
    */
   async deleteMany(keys: string[]) {
+    if (keys.length === 0) return true
     await this.#initialized
 
     keys = keys.map((key) => this.getItemKey(key))

--- a/packages/bentocache/src/drivers/dynamodb.ts
+++ b/packages/bentocache/src/drivers/dynamodb.ts
@@ -267,6 +267,7 @@ export class DynamoDbDriver extends BaseDriver implements CacheDriver {
    * Delete multiple keys from the cache
    */
   async deleteMany(keys: string[]) {
+    if (keys.length === 0) return true
     await Promise.all(keys.map((key) => this.delete(key)))
     return true
   }

--- a/packages/bentocache/src/drivers/file/file.ts
+++ b/packages/bentocache/src/drivers/file/file.ts
@@ -225,6 +225,7 @@ export class FileDriver extends BaseDriver implements CacheDriver {
    * Delete multiple keys from the cache
    */
   async deleteMany(keys: string[]) {
+    if (keys.length === 0) return true
     await Promise.all(keys.map((key) => this.delete(key)))
     return true
   }

--- a/packages/bentocache/src/drivers/memory.ts
+++ b/packages/bentocache/src/drivers/memory.ts
@@ -131,6 +131,7 @@ export class MemoryDriver extends BaseDriver implements L1CacheDriver {
    * Delete multiple keys from the cache
    */
   deleteMany(keys: string[]) {
+    if (keys.length === 0) return true
     for (const key of keys) this.delete(key)
     return true
   }

--- a/packages/bentocache/src/drivers/redis.ts
+++ b/packages/bentocache/src/drivers/redis.ts
@@ -138,6 +138,7 @@ export class RedisDriver extends BaseDriver implements L2CacheDriver {
    * Delete multiple keys from the cache
    */
   async deleteMany(keys: string[]) {
+    if (keys.length === 0) return true
     await this.#connection.del(keys.map((key) => this.getItemKey(key)))
     return true
   }

--- a/packages/bentocache/tests/helpers/driver_test_suite.ts
+++ b/packages/bentocache/tests/helpers/driver_test_suite.ts
@@ -103,6 +103,11 @@ export function registerCacheDriverTestSuite(options: {
     assert.deepEqual(await cache.get('key2'), undefined)
   })
 
+  test('deleteMany() return true when no keys are provided', async ({ assert }) => {
+    const result = await cache.deleteMany([])
+    assert.isFalse(result)
+  })
+
   test('delete() returns true when key is removed', async ({ assert }) => {
     await cache.set('key1', 'value1')
     const result = await cache.delete('key1')


### PR DESCRIPTION
Currently when `deleteMany` is called with an empty keys array we get different results depending on the underlying driver (see tests below). This PR ensures the function `deleteMany` always returns `true` when an empty list of keys is provided independently of the underlying driver.

```
drivers / File driver (tests/drivers/file.spec.ts)
  ✔ deleteMany() with no keys (2.63ms)

drivers / Memory Driver (tests/drivers/memory.spec.ts)
  ✔ deleteMany() with no keys (0.51ms)

drivers / Redis driver (tests/drivers/redis.spec.ts)
  ✖ deleteMany() with no keys (10.98ms)

drivers / Knex | MySQL driver (tests/drivers/knex/mysql.spec.ts)
  ✔ deleteMany() with no keys (21.28ms)

drivers / Knex | MySQL driver (tests/drivers/knex/postgres.spec.ts)
  ✔ deleteMany() with no keys (18.47ms)

drivers / Knex | Better-sqlite3 driver (tests/drivers/knex/sqlite.spec.ts)
  ✔ deleteMany() with no keys (2.44ms)

drivers / Kysely | Mysql driver (tests/drivers/kysely/mysql.spec.ts)
  ✖ deleteMany() with no keys (13.69ms)

drivers / Kysely | Postgres driver (tests/drivers/kysely/postgres.spec.ts)
  ✖ deleteMany() with no keys (8.51ms)

drivers / Kysely | Postgres driver (tests/drivers/kysely/sqlite.spec.ts)
  ✔ deleteMany() with no keys (1.72ms)

drivers / Orchid | Postgres driver (tests/drivers/orchid/postgres.spec.ts)
  ✔ deleteMany() with no keys (12.85ms)
```