### PR TITLE
fix: update clear method to use SCAN instead of KEYS for non-blocking

### DIFF
--- a/.changeset/warm-bananas-doubt.md
+++ b/.changeset/warm-bananas-doubt.md
@@ -1,0 +1,5 @@
+---
+"bentocache": patch
+---
+
+Update clear method to use SCAN instead of KEYS for non-blocking

--- a/packages/bentocache/src/drivers/redis.ts
+++ b/packages/bentocache/src/drivers/redis.ts
@@ -118,10 +118,29 @@ export class RedisDriver extends BaseDriver implements L2CacheDriver {
    * Remove all items from the cache
    */
   async clear() {
-    const keys = await this.#connection.keys(`${this.prefix}*`)
+    let cursor = '0'
+    const COUNT = 1000 // Number of keys to scan in each SCAN iteration
 
-    if (keys.length) {
-      await this.#connection.del(keys)
+    while (true) {
+      /**
+       *  Use SCAN to iterate through keys with the prefix
+       * @see https://redis.io/commands/scan
+       */
+      const [newCursor, keys]: [string, string[]] = await this.#connection.scan(
+        cursor,
+        'MATCH',
+        `${this.prefix}*`,
+        'COUNT',
+        COUNT,
+      )
+
+      if (keys.length) {
+        await this.#connection.del(keys)
+      }
+
+      cursor = newCursor // Update the cursor for the next SCAN iteration
+
+      if (cursor == '0') break // Exit loop when no more keys to scan
     }
   }
 


### PR DESCRIPTION
- Replaced the blocking `KEYS *` command with `SCAN` to avoid performance issues when many keys exist.  
- `SCAN` allows incremental, non-blocking iteration over keys matching the specified prefix.