### PR TITLE
fix: namespace clear doesn't use ioredis `keyPrefix` + namespace clear conflict

### DIFF
--- a/.changeset/silent-trees-raise.md
+++ b/.changeset/silent-trees-raise.md
@@ -1,0 +1,6 @@
+---
+'bentocache': patch
+---
+
+- Fix Redis driver not respecting the `keyPrefix` option from `ioredis` when using the `clear()` method
+- Fix namespace conflict where keys containing a namespace name as a substring were incorrectly cleared. For example, a key named `usersAbc` was incorrectly evicted when calling `cache.namespace('users').clear()`. Now, only keys with an exact namespace prefix match (`users:`) will be cleared.

--- a/packages/bentocache/src/drivers/database/database.ts
+++ b/packages/bentocache/src/drivers/database/database.ts
@@ -131,7 +131,7 @@ export class DatabaseDriver extends BaseDriver implements CacheDriver<true> {
   async clear() {
     await this.#initializer()
 
-    await this.#adapter.clear(this.prefix)
+    await this.#adapter.clear(`${this.prefix}:`)
   }
 
   /**

--- a/packages/bentocache/src/drivers/dynamodb.ts
+++ b/packages/bentocache/src/drivers/dynamodb.ts
@@ -88,7 +88,7 @@ export class DynamoDbDriver extends BaseDriver implements CacheDriver {
         ProjectionExpression: '#key',
         FilterExpression: 'begins_with(#key, :prefix)',
         ExpressionAttributeNames: { '#key': 'key' },
-        ExpressionAttributeValues: { ':prefix': { S: this.prefix } },
+        ExpressionAttributeValues: { ':prefix': { S: `${this.prefix}:` } },
         ExclusiveStartKey: exclusiveStartKey,
       }),
     )

--- a/packages/bentocache/src/drivers/memory.ts
+++ b/packages/bentocache/src/drivers/memory.ts
@@ -105,7 +105,7 @@ export class MemoryDriver extends BaseDriver implements L1CacheDriver {
    */
   async clear() {
     for (const key of this.#cache.keys()) {
-      if (key.startsWith(this.prefix)) {
+      if (key.startsWith(`${this.prefix}:`)) {
         this.#cache.delete(key)
       }
     }

--- a/packages/bentocache/src/drivers/redis.ts
+++ b/packages/bentocache/src/drivers/redis.ts
@@ -113,17 +113,19 @@ export class RedisDriver extends BaseDriver implements L2CacheDriver {
   async clear() {
     let cursor = '0'
     const COUNT = 1000
-
+    const prefix = this.prefix && `${this.prefix}:`
+    const keyPrefix = this.#connection.options.keyPrefix
     do {
       const [newCursor, keys] = await this.#connection.scan(
         cursor,
         'MATCH',
-        `${this.prefix}*`,
+        `${keyPrefix}${prefix}*`,
         'COUNT',
         COUNT,
       )
 
-      if (keys.length) await this.#connection.unlink(keys)
+      if (keys.length)
+        this.#connection.unlink(keys.map((key) => key.slice(keyPrefix.length)));
 
       cursor = newCursor
     } while (cursor !== '0')

--- a/packages/bentocache/src/drivers/redis.ts
+++ b/packages/bentocache/src/drivers/redis.ts
@@ -115,6 +115,7 @@ export class RedisDriver extends BaseDriver implements L2CacheDriver {
     const COUNT = 1000
     const prefix = this.prefix && `${this.prefix}:`
     const keyPrefix = this.#connection.options.keyPrefix
+
     do {
       const [newCursor, keys] = await this.#connection.scan(
         cursor,
@@ -124,8 +125,7 @@ export class RedisDriver extends BaseDriver implements L2CacheDriver {
         COUNT,
       )
 
-      if (keys.length)
-        this.#connection.unlink(keys.map((key) => key.slice(keyPrefix.length)));
+      if (keys.length) this.#connection.unlink(keys.map((key) => key.slice(keyPrefix?.length)))
 
       cursor = newCursor
     } while (cursor !== '0')

--- a/packages/bentocache/src/drivers/redis.ts
+++ b/packages/bentocache/src/drivers/redis.ts
@@ -114,18 +114,19 @@ export class RedisDriver extends BaseDriver implements L2CacheDriver {
     let cursor = '0'
     const COUNT = 1000
     const prefix = this.prefix && `${this.prefix}:`
-    const keyPrefix = this.#connection.options.keyPrefix
+    const connectionKeyPrefix = this.#connection.options.keyPrefix
 
     do {
       const [newCursor, keys] = await this.#connection.scan(
         cursor,
         'MATCH',
-        `${keyPrefix}${prefix}*`,
+        `${connectionKeyPrefix}${prefix}*`,
         'COUNT',
         COUNT,
       )
 
-      if (keys.length) this.#connection.unlink(keys.map((key) => key.slice(keyPrefix?.length)))
+      if (keys.length)
+        this.#connection.unlink(keys.map((key) => key.slice(connectionKeyPrefix?.length)))
 
       cursor = newCursor
     } while (cursor !== '0')

--- a/packages/bentocache/tests/drivers/redis.spec.ts
+++ b/packages/bentocache/tests/drivers/redis.spec.ts
@@ -22,4 +22,28 @@ test.group('Redis driver', (group) => {
     await redis2.disconnect()
     await ioredis.quit()
   })
+
+  test('should works with ioredis keyPrefix', async ({ assert }) => {
+    const ioredis = new IoRedis({ ...REDIS_CREDENTIALS, keyPrefix: 'test:' })
+    const ioRedis2 = new IoRedis({ ...REDIS_CREDENTIALS })
+    const redis2 = new RedisDriver({ connection: ioredis, prefix: 'japa' })
+
+    await redis2.set('key', 'value')
+    await redis2.namespace('foo').set('key', 'value2')
+
+    const r1 = await ioRedis2.get('test:japa:key')
+    const r2 = await ioRedis2.get('test:japa:foo:key')
+
+    await redis2.namespace('foo').clear()
+
+    const r3 = await ioRedis2.get('test:japa:foo:key')
+
+    assert.equal(r1, 'value')
+    assert.equal(r2, 'value2')
+    assert.equal(r3, null)
+
+    await redis2.disconnect()
+    await ioRedis2.quit()
+    await ioredis.quit()
+  })
 })

--- a/packages/bentocache/tests/helpers/driver_test_suite.ts
+++ b/packages/bentocache/tests/helpers/driver_test_suite.ts
@@ -192,4 +192,19 @@ export function registerCacheDriverTestSuite(options: {
     assert.deepEqual(r3, 'value2')
     assert.deepEqual(r4, 'value2')
   })
+
+  test('namespace clear() should only clear prefixed keys', async ({ assert }) => {
+    const users = cache.namespace('users')
+
+    await cache.set('usersAbc', 'value1')
+    await users.set('abc', 'value2')
+
+    await users.clear()
+
+    const r1 = await cache.get('usersAbc')
+    const r2 = await users.get('abc')
+
+    assert.deepEqual(r1, 'value1')
+    assert.isUndefined(r2)
+  })
 }


### PR DESCRIPTION
As per issue #67 