### PR TITLE
feat: addForceFresh option

### DIFF
--- a/.changeset/modern-hotels-visit.md
+++ b/.changeset/modern-hotels-visit.md
@@ -1,0 +1,5 @@
+---
+'bentocache': minor
+---
+
+Added a `forceFresh` option to the `getOrSet` method. This option allows you to force the factory to be re-executed and its result to be cached, even if a valid value is already present in the cache. Can be useful for debugging purposes or when you promptly want to have a fresh value.

--- a/docs/content/docs/options.md
+++ b/docs/content/docs/options.md
@@ -103,6 +103,14 @@ Levels: `global`, `store`, `operation`
 
 A duration to define a hard [timeout](./timeouts.md#hard-timeouts).
 
+### `forceFresh`
+Default: `false`
+
+Levels: `operation`
+
+If `true`, the factory will be re-executed and its result will be cached, even if a valid value is already present in the cache.
+However, if ever your factory is throwing an error, and a graced value is present in the cache, the graced value will be returned instead of the factory result.
+
 ### `lockTimeout`
 
 Default: `undefined`

--- a/packages/bentocache/src/cache/cache_entry/cache_entry_options.ts
+++ b/packages/bentocache/src/cache/cache_entry/cache_entry_options.ts
@@ -40,6 +40,7 @@ export function createCacheEntryOptions(
   const timeout = resolveTtl(options.timeout, null)
   const hardTimeout = resolveTtl(options.hardTimeout, null)
   const lockTimeout = resolveTtl(options.lockTimeout, null)
+  const forceFresh = options.forceFresh ?? false
 
   const self = {
     /**
@@ -101,6 +102,11 @@ export function createCacheEntryOptions(
     lockTimeout,
     onFactoryError: options.onFactoryError ?? defaults.onFactoryError,
     suppressL2Errors: options.suppressL2Errors,
+
+    /**
+     * Force fresh option
+     */
+    forceFresh,
 
     /**
      * Returns a new instance of `CacheItemOptions` with the same

--- a/packages/bentocache/src/types/options/methods_options.ts
+++ b/packages/bentocache/src/types/options/methods_options.ts
@@ -24,7 +24,8 @@ export type SetCommonOptions = Pick<
 export type GetOrSetOptions<T> = {
   key: string
   factory: GetSetFactory<T>
-} & SetCommonOptions
+} & SetCommonOptions &
+  Pick<RawCommonOptions, 'forceFresh'>
 
 /**
  * Options accepted by the `getOrSetForever` method

--- a/packages/bentocache/src/types/options/options.ts
+++ b/packages/bentocache/src/types/options/options.ts
@@ -9,6 +9,13 @@ import type { CacheSerializer, Duration, Emitter, Logger } from '../main.js'
  */
 export type RawCommonOptions = {
   /**
+   * Forces executing the factory even if a valid value is found in cache.
+   * Can be useful for debugging or when you want to force a refresh
+   * @default false
+   */
+  forceFresh?: boolean
+
+  /**
    * The soft timeout. Once this timeout is reached,
    * the factory will try to return a graced value
    * if available


### PR DESCRIPTION
Added a `forceFresh` option to the `getOrSet` method. This option allows you to force the factory to be re-executed and its result to be cached, even if a valid value is already present in the cache. Can be useful for debugging purposes or when you promptly want to have a fresh value.