### PR TITLE
Fix method name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 See documentation at [bentocache.dev](https://bentocache.dev/docs/introduction)
 
-## Why Bentocache ? 
+## Why Bentocache ?
 
 There are already caching libraries for Node: [`keyv`](https://keyv.org/), [`cache-manager`](https://github.com/node-cache-manager/node-cache-manager#readme), or [`unstorage`](https://unstorage.unjs.io/). However, I think that we could rather consider these libraries as bridges that allow different stores to be used via a unified API, rather than true caching solutions as such.
 
@@ -38,7 +38,7 @@ Bentocache is a caching solution aimed at combining performance and flexibility.
 
 ### One-level
 
-The one-level mode is a standard caching method. Choose from a variety of drivers such as **Redis**, **In-Memory**, **Filesystem**, **DynamoDB**, and more, and you're ready to go. 
+The one-level mode is a standard caching method. Choose from a variety of drivers such as **Redis**, **In-Memory**, **Filesystem**, **DynamoDB**, and more, and you're ready to go.
 
 In addition to this, you benefit from many features that allow you to efficiently manage your cache, such as **cache stampede protection**, **grace periods**, **timeouts**, **namespaces**, etc.
 
@@ -57,12 +57,12 @@ All of this is managed invisibly for you via Bentocache. The only thing to do is
 
 The major benefit of multi-tier caching, is that it allows for responses between 2,000x and 5,000x faster. While Redis is fast, accessing RAM is REALLY MUCH faster.
 
-In fact, it's a quite common pattern : to quote an example, it's [what Stackoverflow does](https://nickcraver.com/blog/2019/08/06/stack-overflow-how-we-do-app-caching/#layers-of-cache-at-stack-overflow). 
+In fact, it's a quite common pattern : to quote an example, it's [what Stackoverflow does](https://nickcraver.com/blog/2019/08/06/stack-overflow-how-we-do-app-caching/#layers-of-cache-at-stack-overflow).
 
 
 To give some perspective, here's a simple benchmark that shows the difference between a simple distributed cache ( using Redis ) vs a multi-tier cache ( using Redis + In-memory cache ) :
 
-![Redis vs Multi-tier caching](./assets/redis_vs_mtier.png) 
+![Redis vs Multi-tier caching](./assets/redis_vs_mtier.png)
 
 ## Features
 
@@ -86,7 +86,7 @@ See the [drivers documentation](https://bentocache.dev/docs/cache-drivers) for l
 
 - [Retry queue](https://bentocache.dev/docs/multi-tier#retry-queue-strategy) : When a application fails to publish something to the bus, it is added to a queue and retried later.
 
-### Timeouts 
+### Timeouts
 
 If your factory is taking too long to execute, you can just return a little bit of stale data while keeping the factory running in the background. Next time the entry is requested, it will be already computed and served immediately.
 
@@ -101,7 +101,7 @@ await bento.getOrSet({
   tags: ['tag-1', 'tag-2']
 });
 
-await bento.deleteByTags({ tags: ['tag-1'] });
+await bento.deleteByTag({ tags: ['tag-1'] });
 ```
 
 ### Namespaces
@@ -114,7 +114,7 @@ const users = bento.namespace('users')
 users.set({ key: '32', value: { name: 'foo' } })
 users.set({ key: '33', value: { name: 'bar' } })
 
-users.clear() 
+users.clear()
 ```
 
 ### Events

--- a/docs/content/docs/introduction.md
+++ b/docs/content/docs/introduction.md
@@ -22,7 +22,7 @@ Bentocache is a robust multi-tier caching library for Node.js applications
 - 📝 Easy Prometheus integration and ready-to-use Grafana dashboard
 - 🧩 Easily extendable with your own driver
 
-## Why Bentocache ? 
+## Why Bentocache ?
 
 There are already caching libraries for Node: [`keyv`](https://keyv.org/), [`cache-manager`](https://github.com/node-cache-manager/node-cache-manager#readme), or [`unstorage`](https://unstorage.unjs.io/). However, I think that we could rather consider these libraries as bridges that allow different stores to be used via a unified API, rather than true caching solutions as such.
 
@@ -36,7 +36,7 @@ Bentocache is a caching solution aimed at combining performance and flexibility.
 
 ### One-level
 
-The one-level mode is a standard caching method. Choose from a variety of drivers such as **Redis**, **In-Memory**, **Filesystem**, **DynamoDB**, and more, and you're ready to go. 
+The one-level mode is a standard caching method. Choose from a variety of drivers such as **Redis**, **In-Memory**, **Filesystem**, **DynamoDB**, and more, and you're ready to go.
 
 In addition to this, you benefit from many features that allow you to efficiently manage your cache, such as **cache stampede protection**, **grace periods**, **timeouts**, **namespaces**, etc.
 
@@ -55,7 +55,7 @@ All of this is managed invisibly for you via Bentocache. The only thing to do is
 
 The major benefit of multi-tier caching is that it allows for responses between 2,000x and 5,000x faster. While Redis is fast, accessing RAM is REALLY MUCH faster.
 
-In fact, it's a quite common pattern : to quote an example, it's [what Stackoverflow does](https://nickcraver.com/blog/2019/08/06/stack-overflow-how-we-do-app-caching/#layers-of-cache-at-stack-overflow). 
+In fact, it's a quite common pattern : to quote an example, it's [what Stackoverflow does](https://nickcraver.com/blog/2019/08/06/stack-overflow-how-we-do-app-caching/#layers-of-cache-at-stack-overflow).
 
 
 To give some perspective, here's a simple benchmark that shows the difference between a simple distributed cache ( using Redis ) vs a multi-tier cache ( using Redis + In-memory cache ) :
@@ -99,7 +99,7 @@ Only a Redis driver for the bus is currently available. We probably have drivers
 
 - [Retry queue](./multi_tier.md#retry-queue-strategy) : When an application fails to publish something to the bus, it is added to a queue and retried later.
 
-### Timeouts 
+### Timeouts
 
 If your factory is taking too long to execute, you can just return a little bit of stale data while keeping the factory running in the background. Next time the entry is requested, it will be already computed and served immediately.
 
@@ -114,7 +114,7 @@ await bento.getOrSet({
   tags: ['tag-1', 'tag-2']
 });
 
-await bento.deleteByTags({ tags: ['tag-1'] });
+await bento.deleteByTag({ tags: ['tag-1'] });
 ```
 
 ### Namespaces
@@ -127,7 +127,7 @@ const users = bento.namespace('users')
 users.set({ key: '32', value: { name: 'foo' } })
 users.set({ key: '33', value: { name: 'bar' } })
 
-users.clear() 
+users.clear()
 ```
 
 ### Events
@@ -154,7 +154,7 @@ bento.getOrSet({
 })
 ```
 
-In this case, when only 20% or less of the TTL remains and the entry is requested : 
+In this case, when only 20% or less of the TTL remains and the entry is requested :
 
 - It will return the cached value to the user.
 - Start a background refresh by calling the factory.

--- a/docs/content/docs/tags.md
+++ b/docs/content/docs/tags.md
@@ -5,7 +5,7 @@ summary: Associate tags with your cache keys to easily invalidat a bunch of keys
 # Tags
 
 :::warning
-Tags are available since v1.2.0 and still **experimental**. 
+Tags are available since v1.2.0 and still **experimental**.
 
 We will **not** make breaking changes without a major version, but no guarantees are made about the stability of this feature yet.
 
@@ -30,7 +30,7 @@ await bento.set({ key: 'foo', tags: ['tag-1'] });
 To invalidate all entries linked to a tag:
 
 ```ts
-await bento.deleteByTags({ tags: ['tag-1'] });
+await bento.deleteByTag({ tags: ['tag-1'] });
 ```
 
 Now, imagine that the tags depend on the cached value itself. In that case, you can use [adaptive caching](./adaptive_caching.md) to update tags dynamically based on the computed value.
@@ -107,7 +107,7 @@ Note that we also store the creation date of the entry as `createdAt`.
 Now, we invalidate the `tag-1` tag:
 
 ```ts
-await bento.deleteByTags({ tags: ['tag-1'] });
+await bento.deleteByTag({ tags: ['tag-1'] });
 ```
 
 Instead of scanning and deleting every entry associated with `tag-1`, Bentocache simply stores the invalidation timestamp under a special cache key:
@@ -120,11 +120,11 @@ So, we store the invalidation timestamp of the tag under the key `__bentocache:t
 
 Now, when fetching an entry, Bentocache checks if it was created before the tag was invalidated. If it was, Bentocache considers the entry stale and ignores it.
 
-In fact, the implementation is a bit more complex than that, but that's the general idea. 
+In fact, the implementation is a bit more complex than that, but that's the general idea.
 
 ## Limitations
 
-The main limitation of this system is that you should avoid using too many tags on a single entry. The more tags you use per entry, the more invalidation timestamps Bentocache needs to store and especially check when fetching an entry. This can increase lookup times and impact performance. 
+The main limitation of this system is that you should avoid using too many tags on a single entry. The more tags you use per entry, the more invalidation timestamps Bentocache needs to store and especially check when fetching an entry. This can increase lookup times and impact performance.
 
 In fact, the same issue exists in other systems like Loki, OpenTelemetry, TimescaleDB etc.. where it's known as the "high cardinality" problem. To maintain optimal performance, it's recommended to **keep the number of tags per entry reasonable**.
 

--- a/packages/bentocache/README.md
+++ b/packages/bentocache/README.md
@@ -24,7 +24,7 @@
 
 See documentation at [bentocache.dev](https://bentocache.dev/docs/introduction)
 
-## Why Bentocache ? 
+## Why Bentocache ?
 
 There are already caching libraries for Node: [`keyv`](https://keyv.org/), [`cache-manager`](https://github.com/node-cache-manager/node-cache-manager#readme), or [`unstorage`](https://unstorage.unjs.io/). However, I think that we could rather consider these libraries as bridges that allow different stores to be used via a unified API, rather than true caching solutions as such.
 
@@ -38,7 +38,7 @@ Bentocache is a caching solution aimed at combining performance and flexibility.
 
 ### One-level
 
-The one-level mode is a standard caching method. Choose from a variety of drivers such as **Redis**, **In-Memory**, **Filesystem**, **DynamoDB**, and more, and you're ready to go. 
+The one-level mode is a standard caching method. Choose from a variety of drivers such as **Redis**, **In-Memory**, **Filesystem**, **DynamoDB**, and more, and you're ready to go.
 
 In addition to this, you benefit from many features that allow you to efficiently manage your cache, such as **cache stampede protection**, **grace periods**, **timeouts**, **namespaces**, etc.
 
@@ -57,12 +57,12 @@ All of this is managed invisibly for you via Bentocache. The only thing to do is
 
 The major benefit of multi-tier caching, is that it allows for responses between 2,000x and 5,000x faster. While Redis is fast, accessing RAM is REALLY MUCH faster.
 
-In fact, it's a quite common pattern : to quote an example, it's [what Stackoverflow does](https://nickcraver.com/blog/2019/08/06/stack-overflow-how-we-do-app-caching/#layers-of-cache-at-stack-overflow). 
+In fact, it's a quite common pattern : to quote an example, it's [what Stackoverflow does](https://nickcraver.com/blog/2019/08/06/stack-overflow-how-we-do-app-caching/#layers-of-cache-at-stack-overflow).
 
 
 To give some perspective, here's a simple benchmark that shows the difference between a simple distributed cache ( using Redis ) vs a multi-tier cache ( using Redis + In-memory cache ) :
 
-![Redis vs Multi-tier caching](./assets/redis_vs_mtier.png) 
+![Redis vs Multi-tier caching](./assets/redis_vs_mtier.png)
 
 ## Features
 
@@ -86,7 +86,7 @@ See the [drivers documentation](https://bentocache.dev/docs/cache-drivers) for l
 
 - [Retry queue](https://bentocache.dev/docs/multi-tier#retry-queue-strategy) : When an application fails to publish something to the bus, it is added to a queue and retried later.
 
-### Timeouts 
+### Timeouts
 
 If your factory is taking too long to execute, you can just return a little bit of stale data while keeping the factory running in the background. Next time the entry is requested, it will be already computed and served immediately.
 
@@ -101,7 +101,7 @@ await bento.getOrSet({
   tags: ['tag-1', 'tag-2']
 });
 
-await bento.deleteByTags({ tags: ['tag-1'] });
+await bento.deleteByTag({ tags: ['tag-1'] });
 ```
 
 ### Namespaces
@@ -114,7 +114,7 @@ const users = bento.namespace('users')
 users.set({ key: '32', value: { name: 'foo' } })
 users.set({ key: '33', value: { name: 'bar' } })
 
-users.clear() 
+users.clear()
 ```
 
 ### Events


### PR DESCRIPTION
## Description
This PR makes two small documentation corrections :

1. Fixes the example in the Tagging section to correctly reference the `deleteByTag` method, which matches the actual API implementation :

- In the [`BentoCache`](https://github.com/Julien-R44/bentocache/blob/daf97f0e225423407a68d9937b9d5d54b20931f4/packages/bentocache/src/bento_cache.ts#L221) class:
```ts
async deleteByTag(options: DeleteByTagOptions): Promise<boolean> {
  return this.use().deleteByTag(options)
}
```

- In the [Cache](https://github.com/Julien-R44/bentocache/blob/daf97f0e225423407a68d9937b9d5d54b20931f4/packages/bentocache/src/cache/cache.ts#L205) class implementation:
```ts
async deleteByTag(rawOptions: DeleteByTagOptions): Promise<boolean> {
  const tags = rawOptions.tags
  const options = this.#stack.defaultOptions.cloneWith(rawOptions)

  this.#options.logger.logMethod({ method: 'deleteByTag', cacheName: this.name, tags, options })

  return await this.#stack.createTagInvalidations(tags)
}
```

2. Removes unnecessary trailing whitespace in the Retry queue documentation line

## Changes
- Corrected method name in code example of the documentation from `deleteByTags` to `deleteByTag`
- Removed extra space before the colon in "Retry queue" section

## Why
These changes ensure the documentation accurately reflects the API, helping to prevent confusion for users who might use examples.