### PR TITLE
fix: standardize database credentials with environment variables and …

### DIFF
--- a/packages/bentocache/.env.example
+++ b/packages/bentocache/.env.example
@@ -2,5 +2,19 @@
 REDIS_HOST=localhost
 REDIS_PORT=6379
 
+## Valkey
+VALKEY_HOST=localhost
+VALKEY_PORT=6380
+
+## MySQL
+MYSQL_USER=root
+MYSQL_PASSWORD=root
+MYSQL_DATABASE=mysql
+MYSQL_PORT=3306
+
+## PostgreSQL
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+
 ## DynamoDB
 DYNAMODB_ENDPOINT=http://localhost:8000

--- a/packages/bentocache/src/drivers/file/cleaner.js
+++ b/packages/bentocache/src/drivers/file/cleaner.js
@@ -45,7 +45,13 @@ export async function pruneExpiredFiles({ directory, onError }) {
   for (const dirEntry of dirEntries) {
     if (dirEntry.isDirectory()) continue
 
-    const filePath = join(dirEntry.parentPath, dirEntry.name)
+    /**
+     * "parentPath" was added in Node.js v20.12.0.
+     * We fallback to "path" for older versions of Node.js.
+     */
+    const basePath = typeof dirEntry.parentPath === 'string' ? dirEntry.parentPath : dirEntry.path
+
+    const filePath = join(basePath, dirEntry.name)
     await deleteFileIfExpired({ filePath, onError })
   }
 }

--- a/packages/bentocache/tests/bus/bus.spec.ts
+++ b/packages/bentocache/tests/bus/bus.spec.ts
@@ -320,7 +320,7 @@ test.group('Bus synchronization', () => {
     assert.deepEqual(result, 'bar')
   })
 
-  test('binary encoding/decoding should works fine', async ({ assert, cleanup }, done) => {
+  test('binary encoding/decoding should work fine', async ({ assert, cleanup }, done) => {
     const bus1 = redisBusDriver({ connection: REDIS_CREDENTIALS })
       .factory(null as any)
       .setId('foo')
@@ -383,7 +383,7 @@ test.group('Bus synchronization', () => {
     .waitForDone()
     .disableTimeout()
 
-  test('works with utf8 characters', async ({ assert }, done) => {
+  test('works with utf8 characters', async ({ assert, cleanup }, done) => {
     const bus1 = redisBusDriver({ connection: REDIS_CREDENTIALS })
       .factory(null as any)
       .setId('foo')
@@ -391,6 +391,11 @@ test.group('Bus synchronization', () => {
     const bus2 = redisBusDriver({ connection: REDIS_CREDENTIALS })
       .factory(null as any)
       .setId('bar')
+
+    cleanup(async () => {
+      await bus1.disconnect()
+      await bus2.disconnect()
+    })
 
     const data = {
       keys: ['foo', '1', '2', 'bar', 'key::test', '🚀'],
@@ -405,10 +410,6 @@ test.group('Bus synchronization', () => {
     await sleep(200)
 
     await bus2.publish('foo', data)
-
-    await bus1.disconnect()
-
-    await bus2.disconnect()
 
     await sleep(200)
   }).waitForDone()

--- a/packages/bentocache/tests/cache/one_tier_local.spec.ts
+++ b/packages/bentocache/tests/cache/one_tier_local.spec.ts
@@ -4,7 +4,7 @@ import { sleep } from '@julr/utils/misc'
 import { CacheFactory } from '../../factories/cache_factory.js'
 import { throwingFactory, slowFactory } from '../helpers/index.js'
 
-test.group('One tier tests', () => {
+test.group('One tier cache', () => {
   test('get() returns deserialized value', async ({ assert }) => {
     const { cache } = new CacheFactory().withMemoryL1().create()
 

--- a/packages/bentocache/tests/cache/two_tier.spec.ts
+++ b/packages/bentocache/tests/cache/two_tier.spec.ts
@@ -10,7 +10,7 @@ import { CacheFactory } from '../../factories/cache_factory.js'
 import { L2CacheError, UndefinedValueError } from '../../src/errors.js'
 import { throwingFactory, slowFactory, REDIS_CREDENTIALS } from '../helpers/index.js'
 
-test.group('Cache', () => {
+test.group('Two tier cache', () => {
   test('get() returns null if null is stored', async ({ assert }) => {
     const { cache } = new CacheFactory().withL1L2Config().create()
 
@@ -674,7 +674,7 @@ test.group('Cache', () => {
     assert.deepEqual(r2?.entry.getValue(), { foo: 'bar' })
   })
 
-  test('when local and remote hitted items are logically it should prioritize remote', async ({
+  test('should prioritize remote value when both local and remote items are logically expired', async ({
     assert,
   }) => {
     const { cache, local, remote, stack } = new CacheFactory()

--- a/packages/bentocache/tests/drivers/database.spec.ts
+++ b/packages/bentocache/tests/drivers/database.spec.ts
@@ -5,7 +5,7 @@ import { sleep } from '@julr/utils/misc'
 import { DatabaseDriver } from '../../src/drivers/database/database.js'
 import { KnexAdapter } from '../../src/drivers/database/adapters/knex.js'
 
-test.group('Database', () => {
+test.group('Database driver', () => {
   test('should prune expired items every x seconds', async ({ assert, cleanup }) => {
     const db = knex({
       client: 'better-sqlite3',

--- a/packages/bentocache/tests/drivers/knex/mysql.spec.ts
+++ b/packages/bentocache/tests/drivers/knex/mysql.spec.ts
@@ -3,9 +3,10 @@ import { test } from '@japa/runner'
 import { sleep } from '@julr/utils/misc'
 
 import { createKnexStore } from './helpers.js'
+import { MYSQL_CREDENTIALS } from '../../helpers/index.js'
 import { registerCacheDriverTestSuite } from '../../helpers/driver_test_suite.js'
 
-test.group('Knex | MySQL driver', (group) => {
+test.group('Knex | Mysql driver', (group) => {
   registerCacheDriverTestSuite({
     test,
     group,
@@ -13,24 +14,24 @@ test.group('Knex | MySQL driver', (group) => {
     createDriver: (options) => {
       const db = knex({
         client: 'mysql2',
-        connection: { user: 'root', password: 'root', database: 'mysql', port: 3306 },
+        connection: { ...MYSQL_CREDENTIALS },
       })
 
       return createKnexStore({ connection: db, prefix: 'japa', ...options })
     },
   })
 
-  test('should not throw error when disconnecting immediately', async () => {
+  test('should not throw error when disconnecting immediately', async ({ cleanup }) => {
     const db = knex({
       client: 'mysql2',
-      connection: { user: 'root', password: 'root', database: 'mysql', port: 3306 },
+      connection: { ...MYSQL_CREDENTIALS },
     })
+    cleanup(() => db.destroy())
 
     const store = createKnexStore({ connection: db, prefix: 'japa' })
 
     await store.disconnect()
     await sleep(1000)
     await store.disconnect()
-    await db.destroy()
   })
 })

--- a/packages/bentocache/tests/drivers/knex/postgres.spec.ts
+++ b/packages/bentocache/tests/drivers/knex/postgres.spec.ts
@@ -2,9 +2,10 @@ import knex from 'knex'
 import { test } from '@japa/runner'
 
 import { createKnexStore } from './helpers.js'
+import { POSTGRES_CREDENTIALS } from '../../helpers/index.js'
 import { registerCacheDriverTestSuite } from '../../helpers/driver_test_suite.js'
 
-test.group('Knex | MySQL driver', (group) => {
+test.group('Knex | Postgres driver', (group) => {
   registerCacheDriverTestSuite({
     test,
     group,
@@ -12,7 +13,7 @@ test.group('Knex | MySQL driver', (group) => {
     createDriver: (options) => {
       const db = knex({
         client: 'pg',
-        connection: { user: 'postgres', password: 'postgres' },
+        connection: { ...POSTGRES_CREDENTIALS },
       })
 
       return createKnexStore({ connection: db, prefix: 'japa', ...options })

--- a/packages/bentocache/tests/drivers/kysely/mysql.spec.ts
+++ b/packages/bentocache/tests/drivers/kysely/mysql.spec.ts
@@ -3,6 +3,7 @@ import { createPool } from 'mysql2'
 import { Kysely, MysqlDialect } from 'kysely'
 
 import { createKyselyStore } from './helpers.js'
+import { MYSQL_CREDENTIALS } from '../../helpers/index.js'
 import { registerCacheDriverTestSuite } from '../../../src/test_suite.js'
 
 test.group('Kysely | Mysql driver', (group) => {
@@ -13,7 +14,7 @@ test.group('Kysely | Mysql driver', (group) => {
     createDriver: (options) => {
       const db = new Kysely<any>({
         dialect: new MysqlDialect({
-          pool: createPool({ user: 'root', password: 'root', database: 'mysql', port: 3306 }),
+          pool: createPool({ ...MYSQL_CREDENTIALS }),
         }),
       })
 

--- a/packages/bentocache/tests/drivers/kysely/postgres.spec.ts
+++ b/packages/bentocache/tests/drivers/kysely/postgres.spec.ts
@@ -3,6 +3,7 @@ import { test } from '@japa/runner'
 import { Kysely, PostgresDialect } from 'kysely'
 
 import { createKyselyStore } from './helpers.js'
+import { POSTGRES_CREDENTIALS } from '../../helpers/index.js'
 import { registerCacheDriverTestSuite } from '../../../src/test_suite.js'
 
 test.group('Kysely | Postgres driver', (group) => {
@@ -13,7 +14,7 @@ test.group('Kysely | Postgres driver', (group) => {
     createDriver: (options) => {
       const db = new Kysely<any>({
         dialect: new PostgresDialect({
-          pool: new pg.Pool({ user: 'postgres', password: 'postgres' }),
+          pool: new pg.Pool({ ...POSTGRES_CREDENTIALS }),
         }),
       })
 

--- a/packages/bentocache/tests/drivers/kysely/sqlite.spec.ts
+++ b/packages/bentocache/tests/drivers/kysely/sqlite.spec.ts
@@ -5,7 +5,7 @@ import { Kysely, SqliteDialect } from 'kysely'
 import { createKyselyStore } from './helpers.js'
 import { registerCacheDriverTestSuite } from '../../../src/test_suite.js'
 
-test.group('Kysely | Postgres driver', (group) => {
+test.group('Kysely | Better-sqlite3 driver', (group) => {
   registerCacheDriverTestSuite({
     test,
     group,

--- a/packages/bentocache/tests/drivers/orchid/postgres.spec.ts
+++ b/packages/bentocache/tests/drivers/orchid/postgres.spec.ts
@@ -2,6 +2,7 @@ import { test } from '@japa/runner'
 import { createDb } from 'orchid-orm'
 
 import { createOrchidStore } from './helpers.js'
+import { POSTGRES_CREDENTIALS } from '../../helpers/index.js'
 import { registerCacheDriverTestSuite } from '../../../src/test_suite.js'
 
 test.group('Orchid | Postgres driver', (group) => {
@@ -10,7 +11,7 @@ test.group('Orchid | Postgres driver', (group) => {
     group,
     supportsMilliseconds: false,
     createDriver: (options) => {
-      const db = createDb({ user: 'postgres', password: 'postgres' })
+      const db = createDb({ ...POSTGRES_CREDENTIALS })
 
       return createOrchidStore({ connection: db, prefix: 'japa', ...options })
     },

--- a/packages/bentocache/tests/drivers/redis.spec.ts
+++ b/packages/bentocache/tests/drivers/redis.spec.ts
@@ -13,29 +13,40 @@ test.group('Redis driver', (group) => {
       new RedisDriver({ prefix: 'japa', connection: REDIS_CREDENTIALS, ...options }),
   })
 
-  test('should be able to provide an instance of ioredis', async ({ assert }) => {
+  test('should be able to provide an instance of ioredis', async ({ assert, cleanup }) => {
     const ioredis = new IoRedis(REDIS_CREDENTIALS)
     const redis2 = new RedisDriver({ connection: ioredis })
 
-    assert.equal(redis2.getConnection(), ioredis)
+    cleanup(async () => {
+      await redis2.disconnect()
+      await ioredis.quit()
+    })
 
-    await redis2.disconnect()
-    await ioredis.quit()
+    assert.equal(redis2.getConnection(), ioredis)
   })
 
-  test('should be able to provide an instance of ioredis cluster', async ({ assert }) => {
+  test('should be able to provide an instance of ioredis cluster', async ({ assert, cleanup }) => {
     const cluster = new IoRedisCluster([{ host: '127.0.0.1', port: 7000 }])
     const redis = new RedisDriver({ connection: cluster })
 
-    assert.equal(redis.getConnection(), cluster)
+    cleanup(async () => {
+      await redis.disconnect()
+      cluster.disconnect()
+    })
 
-    await redis.disconnect()
+    assert.equal(redis.getConnection(), cluster)
   }).skip(!!process.env.CI, 'Skipping cluster test on CI')
 
-  test('should works with ioredis keyPrefix', async ({ assert }) => {
+  test('should work with ioredis keyPrefix', async ({ assert, cleanup }) => {
     const ioredis = new IoRedis({ ...REDIS_CREDENTIALS, keyPrefix: 'test:' })
     const ioRedis2 = new IoRedis({ ...REDIS_CREDENTIALS })
     const redis2 = new RedisDriver({ connection: ioredis, prefix: 'japa' })
+
+    cleanup(async () => {
+      await redis2.disconnect()
+      await ioRedis2.quit()
+      await ioredis.quit()
+    })
 
     await redis2.set('key', 'value')
     await redis2.namespace('foo').set('key', 'value2')
@@ -50,8 +61,5 @@ test.group('Redis driver', (group) => {
     assert.equal(r1, 'value')
     assert.equal(r2, 'value2')
     assert.equal(r3, null)
-
-    await ioredis.quit()
-    await ioRedis2.quit()
   })
 })

--- a/packages/bentocache/tests/helpers/index.ts
+++ b/packages/bentocache/tests/helpers/index.ts
@@ -5,7 +5,23 @@ import { sleep } from '@julr/utils/misc'
 import type { GetSetFactory, GetSetFactoryContext } from '../../src/types/helpers.js'
 
 export const BASE_URL = new URL('./tmp/', import.meta.url)
-export const REDIS_CREDENTIALS = { host: 'localhost', port: 6379 }
+
+export const REDIS_CREDENTIALS = {
+  host: process.env.REDIS_HOST || 'localhost',
+  port: Number(process.env.REDIS_PORT) || 6379,
+}
+
+export const MYSQL_CREDENTIALS = {
+  user: process.env.MYSQL_USER || 'root',
+  password: process.env.MYSQL_PASSWORD || 'root',
+  database: process.env.MYSQL_DATABASE || 'mysql',
+  port: Number(process.env.MYSQL_PORT) || 3306,
+}
+
+export const POSTGRES_CREDENTIALS = {
+  user: process.env.POSTGRES_USER || 'postgres',
+  password: process.env.POSTGRES_PASSWORD || 'postgres',
+}
 export const VALKEY_CREDENTIALS = {
   host: process.env.VALKEY_HOST || 'localhost',
   port: Number(process.env.VALKEY_PORT) || 6380,


### PR DESCRIPTION
## Description

This PR refactors the test suite to improve **reliability**, **maintainability**, and **developer experience**. The changes address Node.js compatibility issues, centralize database configuration, improve test cleanup behavior, and standardize test naming conventions.

---

## Summary of Changes

### 1. Fix Node.js Compatibility in File Driver

Fixed a crash in the file driver’s cache pruning logic when running on Node.js versions **prior to v20.12.0**.

Older Node.js versions do not expose the `parentPath` property on `fs.Dirent` objects, which caused path resolution to fail during pruning.

#### Before

~~~js
const filePath = join(dirEntry.parentPath, dirEntry.name)
~~~

#### After

~~~js
const basePath =
  typeof dirEntry.parentPath === 'string'
    ? dirEntry.parentPath
    : dirEntry.path

const filePath = join(basePath, dirEntry.name)
~~~

This ensures compatibility across all supported Node.js versions.

---

### 2. Centralize Database Credentials

Database credentials are now configured via **environment variables** instead of being hardcoded in individual test files.

#### Changes made

- Added centralized exports:
  - `MYSQL_CREDENTIALS`
  - `POSTGRES_CREDENTIALS`

  in:

  ~~~text
  tests/helpers/index.ts
  ~~~

- Updated `.env.example` with all supported configuration options
- Refactored all database driver tests to import credentials from the shared helpers module

---

### 3. Improve Test Cleanup Reliability

Replaced manual `disconnect()` calls with **Japa’s `cleanup()` hook** to ensure resources are released even when tests fail.

#### Before

~~~ts
test('example', async ({ assert }) => {
  const connection = new Connection()
  assert.equal(...)
  await connection.disconnect()
})
~~~

#### After

~~~ts
test('example', async ({ assert, cleanup }) => {
  const connection = new Connection()
  cleanup(() => connection.disconnect())
  assert.equal(...)
})
~~~

---

### 4. Standardize Test Group Naming

Applied consistent **sentence-case naming conventions** across all test groups.

Examples:

- `Redis driver`
- `Knex | Postgres driver`
- `Kysely | Mysql driver`

---

## Outcome

- Improved Node.js compatibility
- Centralized and configurable database setup
- More reliable test cleanup
- Consistent and readable test naming
