### PR TITLE
Fix syntax for pulling products from cache

### DIFF
--- a/docs/content/docs/methods.md
+++ b/docs/content/docs/methods.md
@@ -197,7 +197,7 @@ const missingProducts = await bento.missing({ key: 'products' })
 Get the value of the key, and then delete it from the cache. Returns `undefined` if the key does not exist.
 
 ```ts
-const products = await bento.pull({ key: 'products' })
+const products = await bento.pull('products')
 ```
 
 ## delete


### PR DESCRIPTION
According to the implementation of the pull method, it cannot accept an object as an input parameter. The method signature is: `pull<T = any>(key: string): Promise<T | null | undefined>;`
This pull request fixes this [minor error in the documentation](https://bentocache.dev/docs/methods#pull).