### PR TITLE
feat: add `waitUntil` option for serverless environments

### DIFF
--- a/.changeset/two-loops-jog.md
+++ b/.changeset/two-loops-jog.md
@@ -1,0 +1,5 @@
+---
+'bentocache': minor
+---
+
+Add `waitUntil` option to support grace periods in serverless environments

--- a/packages/bentocache/src/bento_cache_options.ts
+++ b/packages/bentocache/src/bento_cache_options.ts
@@ -80,6 +80,11 @@ export class BentoCacheOptions {
   serializeL1: boolean = true
   onFactoryError?: (error: FactoryError) => void
 
+  /**
+   * A function to register background tasks in serverless environments
+   */
+  waitUntil?: (promise: Promise<unknown>) => void
+
   constructor(options: RawBentoCacheOptions) {
     this.#options = { ...this, ...options }
 
@@ -98,6 +103,7 @@ export class BentoCacheOptions {
 
     this.logger = new Logger(this.#options.logger ?? noopLogger())
     this.onFactoryError = this.#options.onFactoryError
+    this.waitUntil = this.#options.waitUntil
   }
 
   serializeL1Cache(shouldSerialize: boolean = true) {

--- a/packages/bentocache/src/cache/factory_runner.ts
+++ b/packages/bentocache/src/cache/factory_runner.ts
@@ -127,7 +127,8 @@ export class FactoryRunner {
      * And immediately return the fallback value
      */
     if (options.shouldSwr(hasGracedValue)) {
-      this.#runFactory({ key, factory, options, lockReleaser, isBackground: true })
+      const promise = this.#runFactory({ key, factory, options, lockReleaser, isBackground: true })
+      this.#stack.options.waitUntil?.(promise)
       throw new errors.E_FACTORY_SOFT_TIMEOUT(key)
     }
 
@@ -140,6 +141,7 @@ export class FactoryRunner {
           { cache: this.#stack.name, opId: options.id, key },
           `factory timed out after ${timeout?.duration}ms`,
         )
+        this.#stack.options.waitUntil?.(runFactory)
         throw new timeout!.exception(key)
       },
     })

--- a/packages/bentocache/src/types/options/options.ts
+++ b/packages/bentocache/src/types/options/options.ts
@@ -117,6 +117,22 @@ export type RawBentoCacheOptions = {
    * Custom serializer
    */
   serializer?: CacheSerializer
+
+  /**
+   * A function to register background tasks in serverless environments.
+   * This is needed for SWR (Stale-While-Revalidate) to work properly in
+   * serverless platforms like Vercel, Cloudflare Workers, etc.
+   *
+   * Example with Vercel:
+   * ```ts
+   * import { waitUntil } from '@vercel/functions'
+   *
+   * const bento = new BentoCache({
+   *   waitUntil: waitUntil
+   * })
+   * ```
+   */
+  waitUntil?: (promise: Promise<unknown>) => void
 } & Omit<RawCommonOptions, 'tags' | 'skipBusNotify' | 'skipL2Write'>
 
 /**


### PR DESCRIPTION
I'm trying to use bentocache in a serverless environment, however, to properly take advantage of the "grace" (swr) functionality background promises need to be registered with [`waitUntil`](https://vercel.com/changelog/waituntil-is-now-available-for-vercel-functions) so they don't get terminated. I've added support for that, in the two places I think it needed, and it seems to be working correctly on my website. Let me know if you want any changes, or think I missed anything.

I got copilot to generate a summary.

### Summary

This pull request introduces support for registering background tasks in serverless environments via a new `waitUntil` option in `BentoCache`. This is essential for enabling background cache revalidation (SWR) in platforms like Vercel and Cloudflare Workers, ensuring that background tasks can complete even after the main response is sent. The documentation has been updated to explain how and when to use this option, and example usage is provided for common serverless platforms. Additionally, minor formatting and consistency improvements were made to the documentation.

**Serverless background task support:**

* Added a new `waitUntil` option to `BentoCache` (`RawBentoCacheOptions`, `BentoCacheOptions`) to allow registration of background tasks, enabling proper SWR (Stale-While-Revalidate) behavior in serverless environments. This option is now called in relevant code paths when background revalidation is triggered. [[1]](diffhunk://#diff-10d3e48d3f5f02f3ad862a82f1b75e66b72ebff0bbe516abae46748b3fa03a6aR120-R135) [[2]](diffhunk://#diff-d3a8186cf0d2c600b9ecf9900b3182dca110aed2770a2cef582d91885505a607R83-R87) [[3]](diffhunk://#diff-d3a8186cf0d2c600b9ecf9900b3182dca110aed2770a2cef582d91885505a607R106) [[4]](diffhunk://#diff-8d1eed08fddb2e57c5260277c2568b1f24e3f667a8d01257876c5c3158291669L130-R131) [[5]](diffhunk://#diff-8d1eed08fddb2e57c5260277c2568b1f24e3f667a8d01257876c5c3158291669R144)

**Documentation updates:**

* Updated `docs/options.md` to document the new `waitUntil` option, including explanations, usage scenarios, and code examples for Vercel and Cloudflare Workers.
* Minor formatting and consistency improvements in code examples and option descriptions in the documentation. [[1]](diffhunk://#diff-0d68b4e3e35c20c2b38d0d0b40e896d31fe1b1b3a1676f6226a650c8df64d881L25-R26) [[2]](diffhunk://#diff-0d68b4e3e35c20c2b38d0d0b40e896d31fe1b1b3a1676f6226a650c8df64d881R107) [[3]](diffhunk://#diff-0d68b4e3e35c20c2b38d0d0b40e896d31fe1b1b3a1676f6226a650c8df64d881L183-R185)