### PR TITLE
fix: L1 crash when serialize: false with L2 cache

### DIFF
--- a/.changeset/curly-laws-doubt.md
+++ b/.changeset/curly-laws-doubt.md
@@ -1,0 +1,5 @@
+---
+'bentocache': patch
+---
+
+Fixed crash when serialize is false in L1 with an L2 cache. L2 was storing serialized data in L1, causing a TypeError. Now L1 stores raw objects correctly.

--- a/packages/bentocache/src/cache/cache.ts
+++ b/packages/bentocache/src/cache/cache.ts
@@ -82,7 +82,7 @@ export class Cache implements CacheProvider {
       const isRemoteItemValid = await this.#stack.isEntryValid(remoteItem)
 
       if (isRemoteItemValid) {
-        this.#stack.l1?.set(key, remoteItem!.entry.serialize(), options)
+        this.#stack.l1?.set(key, this.#stack.prepareForL1(remoteItem!.entry), options)
         this.#stack.emit(cacheEvents.hit(key, remoteItem!.entry.getValue(), this.name))
         this.#options.logger.logL2Hit({ cacheName: this.name, key, options })
         message.hit = true
@@ -92,7 +92,7 @@ export class Cache implements CacheProvider {
       }
 
       if (remoteItem && options.isGraceEnabled()) {
-        this.#stack.l1?.set(key, remoteItem.entry.serialize(), options)
+        this.#stack.l1?.set(key, this.#stack.prepareForL1(remoteItem.entry), options)
         this.#stack.emit(cacheEvents.hit(key, remoteItem.entry.serialize(), this.name, 'l2', true))
         this.#options.logger.logL2Hit({ cacheName: this.name, key, options, graced: true })
         message.hit = true

--- a/packages/bentocache/src/cache/cache_entry/cache_entry.ts
+++ b/packages/bentocache/src/cache/cache_entry/cache_entry.ts
@@ -78,14 +78,17 @@ export class CacheEntry {
     return this
   }
 
-  serialize() {
-    const raw = {
+  toRaw() {
+    return {
       value: this.#value,
       createdAt: this.#createdAt,
       logicalExpiration: this.#logicalExpiration,
       ...(this.#tags.length > 0 && { tags: this.#tags }),
     }
+  }
 
+  serialize() {
+    const raw = this.toRaw()
     if (this.#serializer) return this.#serializer.serialize(raw)
     return raw
   }

--- a/packages/bentocache/src/cache/cache_stack.ts
+++ b/packages/bentocache/src/cache/cache_stack.ts
@@ -9,6 +9,7 @@ import { BaseDriver } from '../drivers/base_driver.js'
 import { RemoteCache } from './facades/remote_cache.js'
 import { cacheEvents } from '../events/cache_events.js'
 import { cacheOperation } from '../tracing_channels.js'
+import type { CacheEntry } from './cache_entry/cache_entry.js'
 import type { GetSetHandler } from './get_set/get_set_handler.js'
 import type { BentoCacheOptions } from '../bento_cache_options.js'
 import type { GetCacheValueReturn } from '../types/internals/index.js'
@@ -123,6 +124,14 @@ export class CacheStack extends BaseDriver {
 
   emit(event: CacheEvent) {
     return this.emitter.emit(event.name, event.data)
+  }
+
+  /**
+   * Prepare a cache entry for L1 storage, returning serialized
+   * or raw data based on the serializeL1 option
+   */
+  prepareForL1(entry: CacheEntry) {
+    return this.options.serializeL1 ? entry.serialize() : entry.toRaw()
   }
 
   /**

--- a/packages/bentocache/src/cache/get_set/two_tier_handler.ts
+++ b/packages/bentocache/src/cache/get_set/two_tier_handler.ts
@@ -62,7 +62,7 @@ export class TwoTierHandler {
       message.tier = 'l2'
     }
 
-    this.stack.l1?.set(key, item.entry.serialize(), options)
+    this.stack.l1?.set(key, this.stack.prepareForL1(item.entry), options)
 
     this.#emit(cacheEvents.hit(key, item.entry.getValue(), this.stack.name, 'l2'))
     return item.entry.getValue()

--- a/packages/bentocache/tests/cache/two_tier.spec.ts
+++ b/packages/bentocache/tests/cache/two_tier.spec.ts
@@ -10,6 +10,75 @@ import { CacheFactory } from '../../factories/cache_factory.js'
 import { L2CacheError, UndefinedValueError } from '../../src/errors.js'
 import { throwingFactory, slowFactory, REDIS_CREDENTIALS } from '../helpers/index.js'
 
+test.group('Two tier cache | serialize: false on L1', () => {
+  test('L2 hit should correctly refill L1 when serialize is false', async ({ assert }) => {
+    const { cache, local, remote, stack } = new CacheFactory()
+      .withMemoryL1({ serialize: false })
+      .withL1L2Config()
+      .create()
+
+    await remote.set('foo', JSON.stringify({ value: { name: 'John' } }), stack.defaultOptions)
+
+    const r1 = await cache.get({ key: 'foo' })
+    assert.deepEqual(r1, { name: 'John' })
+
+    const r2 = await cache.get({ key: 'foo' })
+    assert.deepEqual(r2, { name: 'John' })
+
+    const l1Entry = local.get('foo', stack.defaultOptions)
+    assert.deepEqual(l1Entry?.entry.getValue(), { name: 'John' })
+    assert.isNotString(l1Entry?.entry.getValue())
+  })
+
+  test('getOrSet L2 hit should correctly refill L1 when serialize is false', async ({ assert }) => {
+    const { cache, remote, stack } = new CacheFactory()
+      .withMemoryL1({ serialize: false })
+      .withL1L2Config()
+      .create()
+
+    await remote.set('foo', JSON.stringify({ value: 'bar' }), stack.defaultOptions)
+
+    const r1 = await cache.getOrSet({
+      key: 'foo',
+      factory: throwingFactory('should not be called'),
+    })
+    assert.deepEqual(r1, 'bar')
+
+    const r2 = await cache.getOrSet({
+      key: 'foo',
+      factory: throwingFactory('should not be called'),
+    })
+    assert.deepEqual(r2, 'bar')
+  })
+
+  test('grace period backoff should correctly store in L1 when serialize is false', async ({
+    assert,
+  }) => {
+    const { cache } = new CacheFactory()
+      .withMemoryL1({ serialize: false })
+      .withL1L2Config()
+      .merge({ ttl: 100, grace: '10m', timeout: null })
+      .create()
+
+    const r1 = await cache.getOrSet({ key: 'key1', factory: () => ({ foo: 'bar' }) })
+
+    await sleep(100)
+
+    const r2 = await cache.getOrSet({
+      key: 'key1',
+      factory: () => {
+        throw new Error('factory error')
+      },
+    })
+
+    assert.deepEqual(r1, { foo: 'bar' })
+    assert.deepEqual(r2, { foo: 'bar' })
+
+    const r3 = await cache.get({ key: 'key1' })
+    assert.deepEqual(r3, { foo: 'bar' })
+  })
+})
+
 test.group('Two tier cache', () => {
   test('get() returns null if null is stored', async ({ assert }) => {
     const { cache } = new CacheFactory().withL1L2Config().create()


### PR DESCRIPTION
### Problem

When using a two-tier cache with `serialize: false` on the L1 memory driver, reading a value that exists only in L2 causes a crash on subsequent L1 reads:

```
TypeError: Cannot read properties of undefined (reading 'deserialize')
```

**Root cause:** During L2-to-L1 refill, the code unconditionally called `entry.serialize()`, storing a serialized string into L1. Since L1 has no deserializer when `serialize: false`, the next read from L1 crashes in `CacheEntry.fromDriver()`.

This affected three code paths:
- `cache.get()` - L2 hit refill to L1
- `cache.get()` - graced L2 value refill to L1
- `cache.getOrSet()` via `TwoTierHandler.#returnRemoteCacheValue()`

### Fix

- Extracted `toRaw()` method from `CacheEntry.serialize()` to return the plain object without serialization
- Added `prepareForL1(entry)` helper on `CacheStack` that returns `entry.serialize()` or `entry.toRaw()` based on the `serializeL1` option
- Replaced all three L2-to-L1 refill paths to use `prepareForL1()` instead of unconditional `serialize()`

### Tests added

- **`L2 hit should correctly refill L1 when serialize is false`** — `cache.get()` path: L2 hit refills L1, subsequent L1 read works and stores an object (not a string)
- **`getOrSet L2 hit should correctly refill L1 when serialize is false`** — `cache.getOrSet()` path: L2 hit refills L1, subsequent call reads from L1 without error

### Closes #111 
