### PR TITLE
fix(cache): pass graced entry to factory in SWR path

### DIFF
--- a/packages/bentocache/src/cache/factory_runner.ts
+++ b/packages/bentocache/src/cache/factory_runner.ts
@@ -137,7 +137,7 @@ export class FactoryRunner {
      * And immediately return the fallback value
      */
     if (options.shouldSwr(hasGracedValue)) {
-      this.#runFactory({ key, factory, options, lockReleaser, isBackground: true })
+      this.#runFactory({ key, factory, options, lockReleaser, isBackground: true, gracedValue })
       throw new errors.E_FACTORY_SOFT_TIMEOUT(key)
     }
 

--- a/packages/bentocache/tests/cache/factory_context.spec.ts
+++ b/packages/bentocache/tests/cache/factory_context.spec.ts
@@ -110,14 +110,17 @@ test.group('Factory Context', () => {
 
     await sleep(100)
 
+    let gracedEntryValue;
+
     const r1 = await cache.getOrSet({
       key: 'foo',
       factory: ({ gracedEntry }) => {
-        assert.deepEqual(gracedEntry?.value, 'bar')
-        return gracedEntry?.value
+        gracedEntryValue = gracedEntry?.value
+        return gracedEntryValue
       },
     })
 
+    assert.deepEqual(gracedEntryValue, 'bar')
     assert.deepEqual(r1, 'bar')
   })
 })


### PR DESCRIPTION
In SWR mode, `getOrSet` could invoke the factory with`gracedEntry` set to `undefined` even when a stale value existed. This happened because the SWR background factory run did not receive `gracedValue`. `gracedValue` is now forwarded in that path so `gracedEntry.value` is consistently available.

I went ahead and adjusted tests so previous codebase fails, but new one passes. Previous assertion actually throws with `AssertionError: expected undefined to deeply equal 'bar'` but it’s not thrown since grace period for that test is set to 2 minutes and the graced value is returned, but that graced value is not available in factory context, only as return value of `getOrSet` call.